### PR TITLE
fix: biolink v2.1 related fixes

### DIFF
--- a/__test__/data/chemicals_targeting_IL1_Signaling_Pathway.json
+++ b/__test__/data/chemicals_targeting_IL1_Signaling_Pathway.json
@@ -10,7 +10,7 @@
                     "categories": ["biolink:Gene"]
                 },
                 "n2": {
-                    "categories": ["biolink:ChemicalSubstance"]
+                    "categories": ["biolink:SmallMolecule"]
                 }
             },
             "edges": {

--- a/__test__/data/increased_urinary_glycerol_affects_glycerol.json
+++ b/__test__/data/increased_urinary_glycerol_affects_glycerol.json
@@ -7,7 +7,7 @@
                     "categories": ["biolink:PhenotypicFeature"]
                 },
                 "n1": {
-                    "categories": ["biolink:ChemicalSubstance"]
+                    "categories": ["biolink:SmallMolecule"]
                 }
             },
             "edges": {

--- a/__test__/integration/biolink.test.js
+++ b/__test__/integration/biolink.test.js
@@ -34,8 +34,8 @@ describe("Test BioLinkModel class", () => {
     describe("Test getDescendants function", () => {
         test("if input is in biolink model, return all its desendants and itself", () => {
             const res = biolink.getDescendantClasses('MolecularEntity');
-            expect(res).toContain("Drug");
-            expect(res).toContain("Gene");
+            expect(res).toContain("SmallMolecule");
+            expect(res).toContain("NucleicAcidEntity");
             expect(res).toContain("MolecularEntity");
         })
 


### PR DESCRIPTION
ChemicalSubstance -> SmallMolecule, MolecularEntity has different children
tests are still failing - perhaps use APIs that BTE doesn't ingest currently