### PR TITLE
feat: switch to SRI Resolver

### DIFF
--- a/src/update_nodes.js
+++ b/src/update_nodes.js
@@ -35,8 +35,9 @@ module.exports = class NodesUpdateHandler {
    * @param {object} curies - each key represents the category, e.g. gene, value is an array of curies.
    */
   async _getEquivalentIDs(curies) {
-    const resolver = new id_resolver.Resolver('biolink');
-    const equivalentIDs = await resolver.resolve(curies);
+    // const resolver = new id_resolver.Resolver('biolink');
+    // const equivalentIDs = await resolver.resolve(curies);
+    const equivalentIDs = await id_resolver.resolveSRI(curies);
     return equivalentIDs;
   }
 


### PR DESCRIPTION
Needs https://github.com/biothings/biomedical_id_resolver.js/pull/75 to be merged first. 

Merge together with https://github.com/biothings/call-apis.js/pull/29 to enable SRI resolver.

Related to https://github.com/biothings/BioThings_Explorer_TRAPI/issues/249.

- switch to using SRI Resolver