### PR TITLE
fix: use unique KG edge IDs

### DIFF
--- a/__test__/integration/graph/graph.test.js
+++ b/__test__/integration/graph/graph.test.js
@@ -106,14 +106,14 @@ describe("Test graph class", () => {
         expect(g.nodes["inputPrimaryID-qg1"]._qgID).toEqual("qg1");
         expect(Array.from(g.nodes["inputPrimaryID-qg1"]._targetNodes)).toEqual(['outputPrimaryID-qg2']);
         expect(Array.from(g.nodes["inputPrimaryID-qg1"]._targetQGNodes)).toEqual(['qg2']);
-        expect(g.edges).toHaveProperty('inputPrimaryID-biolink:predicate1-outputPrimaryID');
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].apis)).toEqual(['API1']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].sources)).toEqual(['source1']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].publications)).toEqual(['PMID:1', 'PMID:2']);
-        expect(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].attributes).toHaveProperty('relation', 'relation1')
+        expect(g.edges).toHaveProperty('0719696e40f7ef74a5899eaf308f5067');
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].apis)).toEqual(['API1']);
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].sources)).toEqual(['source1']);
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].publications)).toEqual(['PMID:1', 'PMID:2']);
+        expect(g.edges['0719696e40f7ef74a5899eaf308f5067'].attributes).toHaveProperty('relation', 'relation1')
     })
 
-    test("Multiple query results for same edge are correctly updated", () => {
+    test("Multiple query results are correctly updated for two edges having same input, predicate and output", () => {
         const g = new graph();
         g.update([record1, record2]);
         expect(g.nodes).toHaveProperty("outputPrimaryID-qg2");
@@ -126,11 +126,18 @@ describe("Test graph class", () => {
         expect(g.nodes["inputPrimaryID-qg1"]._qgID).toEqual("qg1");
         expect(Array.from(g.nodes["inputPrimaryID-qg1"]._targetNodes)).toEqual(['outputPrimaryID-qg2']);
         expect(Array.from(g.nodes["inputPrimaryID-qg1"]._targetQGNodes)).toEqual(['qg2']);
-        expect(g.edges).toHaveProperty('inputPrimaryID-biolink:predicate1-outputPrimaryID');
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].apis)).toEqual(['API1', 'API2']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].sources)).toEqual(['source1', 'source2']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].publications)).toEqual(['PMID:1', 'PMID:2', 'PMC:1', 'PMC:2']);
-        expect(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].attributes).toHaveProperty('relation', 'relation2')
+
+        expect(g.edges).toHaveProperty('0719696e40f7ef74a5899eaf308f5067');
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].apis)).toEqual(['API1']);
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].sources)).toEqual(['source1']);
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].publications)).toEqual(['PMID:1', 'PMID:2']);
+        expect(g.edges['0719696e40f7ef74a5899eaf308f5067'].attributes).toHaveProperty('relation', 'relation1')
+
+        expect(g.edges).toHaveProperty('00cc8c4fe1a391c243c3c3e762d1ea73');
+        expect(Array.from(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].apis)).toEqual(['API2']);
+        expect(Array.from(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].sources)).toEqual(['source2']);
+        expect(Array.from(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].publications)).toEqual(['PMC:1', 'PMC:2']);
+        expect(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].attributes).toHaveProperty('relation', 'relation2')
     })
 
     test("Multiple query results for different edges are correctly updated", () => {
@@ -146,15 +153,23 @@ describe("Test graph class", () => {
         expect(g.nodes["inputPrimaryID-qg1"]._qgID).toEqual("qg1");
         expect(Array.from(g.nodes["inputPrimaryID-qg1"]._targetNodes)).toEqual(['outputPrimaryID-qg2']);
         expect(Array.from(g.nodes["inputPrimaryID-qg1"]._targetQGNodes)).toEqual(['qg2']);
-        expect(g.edges).toHaveProperty('inputPrimaryID-biolink:predicate1-outputPrimaryID');
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].apis)).toEqual(['API1', 'API2']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].sources)).toEqual(['source1', 'source2']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].publications)).toEqual(['PMID:1', 'PMID:2', 'PMC:1', 'PMC:2']);
-        expect(g.edges['inputPrimaryID-biolink:predicate1-outputPrimaryID'].attributes).toHaveProperty('relation', 'relation2');
-        expect(g.edges).toHaveProperty('inputPrimaryID-biolink:predicate2-outputPrimaryID');
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate2-outputPrimaryID'].apis)).toEqual(['API3']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate2-outputPrimaryID'].sources)).toEqual(['source3']);
-        expect(Array.from(g.edges['inputPrimaryID-biolink:predicate2-outputPrimaryID'].publications)).toEqual(['PMC:3', 'PMC:4']);
-        expect(g.edges['inputPrimaryID-biolink:predicate2-outputPrimaryID'].attributes).toHaveProperty('relation', 'relation3')
+
+        expect(g.edges).toHaveProperty('0719696e40f7ef74a5899eaf308f5067');
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].apis)).toEqual(['API1']);
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].sources)).toEqual(['source1']);
+        expect(Array.from(g.edges['0719696e40f7ef74a5899eaf308f5067'].publications)).toEqual(['PMID:1', 'PMID:2']);
+        expect(g.edges['0719696e40f7ef74a5899eaf308f5067'].attributes).toHaveProperty('relation', 'relation1')
+
+        expect(g.edges).toHaveProperty('00cc8c4fe1a391c243c3c3e762d1ea73');
+        expect(Array.from(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].apis)).toEqual(['API2']);
+        expect(Array.from(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].sources)).toEqual(['source2']);
+        expect(Array.from(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].publications)).toEqual(['PMC:1', 'PMC:2']);
+        expect(g.edges['00cc8c4fe1a391c243c3c3e762d1ea73'].attributes).toHaveProperty('relation', 'relation2')
+
+        expect(g.edges).toHaveProperty('13219cef22cc15f78b115b3e5859f7e9');
+        expect(Array.from(g.edges['13219cef22cc15f78b115b3e5859f7e9'].apis)).toEqual(['API3']);
+        expect(Array.from(g.edges['13219cef22cc15f78b115b3e5859f7e9'].sources)).toEqual(['source3']);
+        expect(Array.from(g.edges['13219cef22cc15f78b115b3e5859f7e9'].publications)).toEqual(['PMC:3', 'PMC:4']);
+        expect(g.edges['13219cef22cc15f78b115b3e5859f7e9'].attributes).toHaveProperty('relation', 'relation3')
     })
 })

--- a/__test__/unittest/helper.test.js
+++ b/__test__/unittest/helper.test.js
@@ -288,7 +288,7 @@ describe("Test helper moduler", () => {
         })
     })
 
-    describe("Test _createUniqueEdgeID function", () => {
+    describe("Test _getKGEdgeID function", () => {
         const edgeObject = {
             isReversed() {
                 return false;
@@ -311,8 +311,8 @@ describe("Test helper moduler", () => {
                 }]
             },
         }
-        const res = helper._createUniqueEdgeID(record);
-        expect(res).toEqual('input-output-MyGene.info API-CPDB')
+        const res = helper._getKGEdgeID(record);
+        expect(res).toEqual('6b49bd17fb00886e05ec1f16def3c0da')
     })
 
     describe("Test _getInputCategory function", () => {

--- a/src/helper.js
+++ b/src/helper.js
@@ -49,18 +49,13 @@ module.exports = class QueryGraphHelper {
   }
 
   _getKGEdgeID(record) {
-    return [this._getInputID(record), this._getPredicate(record), this._getOutputID(record)].join('-');
-  }
-
-  _createUniqueEdgeID(record) {
     const edgeMetaData = [
       this._getInputID(record),
       this._getOutputID(record),
       this._getAPI(record),
       this._getSource(record),
     ];
-    // return this._generateHash(edgeMetaData.join('-'));
-    return edgeMetaData.join('-');
+    return this._generateHash(edgeMetaData.join('-'));
   }
 
   _getInputCategory(record) {


### PR DESCRIPTION
This pull request uses the following elements from `record` in order to produce unique IDs for non-duplicate KG edges:

```
       this._getInputID(record),
       this._getOutputID(record),
       this._getAPI(record),
       this._getSource(record),
```

It concatenates those elements and hashes the resulting string in order to avoid excessively long IDs.

Close https://github.com/biothings/BioThings_Explorer_TRAPI/issues/286