### PR TITLE
Yield to async event loop when performing deepClones

### DIFF
--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -124,7 +124,7 @@ module.exports = class BatchEdgeQueryHandler {
     } else {
       debug('Start to convert qEdges into BTEEdges....');
       const edgeConverter = new QEdge2BTEEdgeHandler(nonCachedEdges, this.kg);
-      const bteEdges = edgeConverter.convert(nonCachedEdges);
+      const bteEdges = await edgeConverter.convert(nonCachedEdges);
       debug(`qEdges are successfully converted into ${bteEdges.length} BTEEdges....`);
       this.logs = [...this.logs, ...edgeConverter.logs];
       if (bteEdges.length === 0 && cachedResults.length === 0) {
@@ -163,7 +163,7 @@ module.exports = class BatchEdgeQueryHandler {
     } else {
       debug('Start to convert qEdges into BTEEdges....');
       const edgeConverter = new QEdge2BTEEdgeHandler(nonCachedEdges, this.kg);
-      const bteEdges = edgeConverter.convert(nonCachedEdges);
+      const bteEdges = await edgeConverter.convert(nonCachedEdges);
       debug(`qEdges are successfully converted into ${bteEdges.length} BTEEdges....`);
       this.logs = [...this.logs, ...edgeConverter.logs];
       if (bteEdges.length === 0 && cachedResults.length === 0) {


### PR DESCRIPTION
*(continuation of https://github.com/biothings/api-respone-transform.js/pull/16)*

This PR causes existing calls to `cloneDeep` to yield to the event loop, allowing the server to poll for new requests, if the operation takes longer than 3ms. This time may be changed by setting `SETIMMEDIATE_TIME` to an integer in ms.

Related and recommended to pull simultaneously: https://github.com/biothings/api-respone-transform.js/pull/17