### PR TITLE
fix: :sparkles: Make use of API list option to filter out KG ops

### DIFF
--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -3,8 +3,6 @@ const QEdge2BTEEdgeHandler = require('./qedge2bteedge');
 const NodesUpdateHandler = require('./update_nodes');
 const debug = require('debug')('bte:biothings-explorer-trapi:batch_edge_query');
 const CacheHandler = require('./cache_handler');
-const utils = require('./utils');
-const LogEntry = require('./log_entry');
 
 module.exports = class BatchEdgeQueryHandler {
   constructor(kg, resolveOutputIDs = true, options) {
@@ -13,6 +11,7 @@ module.exports = class BatchEdgeQueryHandler {
     this.logs = [];
     this.caching = options && options.caching;
     this.resolveOutputIDs = resolveOutputIDs;
+    this.api_list = options && options.apis
   }
 
   /**
@@ -110,7 +109,7 @@ module.exports = class BatchEdgeQueryHandler {
       query_res = [];
     } else {
       debug('Start to convert qEdges into BTEEdges....');
-      const edgeConverter = new QEdge2BTEEdgeHandler(nonCachedEdges, this.kg);
+      const edgeConverter = new QEdge2BTEEdgeHandler(nonCachedEdges, this.kg, {apis: this.api_list});
       const bteEdges = await edgeConverter.convert(nonCachedEdges);
       debug(`qEdges are successfully converted into ${bteEdges.length} BTEEdges....`);
       this.logs = [...this.logs, ...edgeConverter.logs];

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
   _loadMetaKG() {
     const kg = new meta_kg.default(this.path, this.predicatePath);
     debug(`Query options are: ${JSON.stringify(this.options)}`);
+
     debug(`SmartAPI Specs read from path: ${this.path}`);
     kg.constructMetaKGSync(this.includeReasoner, this.options);
     return kg;
@@ -143,7 +144,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
   }
 
   _createBatchEdgeQueryHandlersForCurrent(currentEdge, kg) {
-    let handler = new BatchEdgeQueryHandler(kg, this.resolveOutputIDs);
+    let handler = new BatchEdgeQueryHandler(kg, this.resolveOutputIDs, {apis: this.options.apiNames});
     handler.setEdges(currentEdge);
     return handler;
   }

--- a/src/qedge2bteedge.js
+++ b/src/qedge2bteedge.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const LogEntry = require('./log_entry');
-const config = require('./config');
 const ID_WITH_PREFIXES = ['MONDO', 'DOID', 'UBERON', 'EFO', 'HP', 'CHEBI', 'CL', 'MGI', 'NCIT'];
 const debug = require('debug')('bte:biothings-explorer-trapi:qedge2btedge');
 
@@ -11,10 +10,11 @@ const setImmediatePromise = () => {
 };
 
 module.exports = class QEdge2BTEEdgeHandler {
-  constructor(qEdges, kg) {
+  constructor(qEdges, kg, options) {
     this.qEdges = qEdges;
     this.kg = kg;
     this.logs = [];
+    this.api_list = options && options.apis;
   }
 
   setQEdges(qEdges) {
@@ -50,6 +50,10 @@ module.exports = class QEdge2BTEEdgeHandler {
     };
     debug(`KG Filters: ${JSON.stringify(filterCriteria, null, 2)}`);
     let smartapi_edges = kg.filter(filterCriteria);
+    //simple list of api ids fron config
+    let apis_ids = this.api_list.map( api => api.id);
+    //filter out ops from APIs not specified in config
+    smartapi_edges = smartapi_edges.filter(op => apis_ids.includes(op.association.smartapi.id));
     smartapi_edges = smartapi_edges.map((item) => {
       item.reasoner_edge = qEdge;
       return item;


### PR DESCRIPTION
config API list is used to further filter ops returned from KG.  Previously this list was not used at all, the ops only had to meet the input/output criteria, that's why other API ops would be included from the data files. This change will apply to both sync and async queries.
