### PR TITLE
Remove uses of cloneDeep in qedge2bteedge

### DIFF
--- a/src/qedge2bteedge.js
+++ b/src/qedge2bteedge.js
@@ -90,7 +90,7 @@ module.exports = class QEdge2BTEEdgeHandler {
         if (entity.semanticType === inputType && inputID in entity.dbIDs) {
           await Promise.all(entity.dbIDs[inputID].map(async (id) => {
             let blockingSince = Date.now();
-            const edge = smartAPIEdge;
+            const edge = { ...smartAPIEdge };
             if (blockingSince + (parseInt(process.env.SETIMMEDIATE_TIME) || 3) < Date.now()) {
               await setImmediatePromise();
               blockingSince = Date.now();
@@ -162,7 +162,7 @@ module.exports = class QEdge2BTEEdgeHandler {
     }
     if (Object.keys(id_mapping).length > 0) {
       let blockingSince = Date.now();
-      const edge = smartAPIEdge;
+      const edge = { ...smartAPIEdge };
       if (blockingSince + (parseInt(process.env.SETIMMEDIATE_TIME) || 3) < Date.now()) {
         await setImmediatePromise();
         blockingSince = Date.now();
@@ -196,7 +196,7 @@ module.exports = class QEdge2BTEEdgeHandler {
       resolvedIDs[curie].map((entity) => {
         if (entity.semanticType === inputType && inputID in entity.dbIDs) {
           entity.dbIDs[inputID].map((id) => {
-            const edge = smartAPIEdge;
+            const edge = { ...smartAPIEdge };
             edge.input = { queryInputs: id, ...edge.query_operation.templateInputs };
             edge.input_resolved_identifiers = {
               [curie]: [entity],
@@ -257,7 +257,7 @@ module.exports = class QEdge2BTEEdgeHandler {
       });
     }
     if (Object.keys(id_mapping).length > 0) {
-      const edge = smartAPIEdge;
+      const edge = { ...smartAPIEdge };
       edge.input = { queryInputs: inputs, ...edge.query_operation.templateInputs };
       edge.input_resolved_identifiers = input_resolved_identifiers;
       edge.original_input = id_mapping;


### PR DESCRIPTION
*(addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/323)*

This PR removes uses of `cloneDeep`. Edges which were previously cloned are not used or edited in any way after being converted. Some `qedges` are converted to multiple `BTEEdges` with different parameters added in the process, meaning that `new = { ...original }` assignment with references should suffice. Testing several queries, including one and two hop, etc, shows no change in outputs.