### PR TITLE
Support threaded endpoint request handling

### DIFF
--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -5,6 +5,7 @@ const debug = require('debug')('bte:biothings-explorer-trapi:batch_edge_query');
 const CacheHandler = require('./cache_handler');
 const utils = require('./utils');
 const LogEntry = require('./log_entry');
+const { parentPort } = require('worker_threads');
 
 module.exports = class BatchEdgeQueryHandler {
   constructor(kg, resolveOutputIDs = true, options) {
@@ -108,6 +109,9 @@ module.exports = class BatchEdgeQueryHandler {
 
     if (nonCachedEdges.length === 0) {
       query_res = [];
+      if (parentPort) {
+        parentPort.postMessage({ cacheDone: true });
+      }
     } else {
       debug('Start to convert qEdges into BTEEdges....');
       const edgeConverter = new QEdge2BTEEdgeHandler(nonCachedEdges, this.kg);


### PR DESCRIPTION
*Required for https://github.com/biothings/BioThings_Explorer_TRAPI/issues/333*

This PR allows a worker thread to report to the thread handler that it has completed the process of caching (or has failed to cache/doesn't need to cache) so the handler may safely terminate the thread. 

This allows the thread handler to only terminate a thread once it has both completed processing the request *and* finished caching, as caching does not block request processing and response to the user.