### PR TITLE
fix: :sparkles: update entity max logic

### DIFF
--- a/src/exceptions/bte_error.js
+++ b/src/exceptions/bte_error.js
@@ -1,0 +1,19 @@
+class BTEError extends Error {
+    constructor(message = 'Query aborted',
+    name = 'QueryAborted',
+    code = '501',
+     ...params) {
+      super(...params);
+  
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, BTEError);
+      }
+  
+      this.name = name;
+      this.message = message;
+      this.statusCode = code;
+    }
+  }
+  
+  module.exports = BTEError;
+  

--- a/src/exceptions/invalid_query_graph_error.js
+++ b/src/exceptions/invalid_query_graph_error.js
@@ -6,7 +6,7 @@ class InvalidQueryGraphError extends Error {
     super(...params);
 
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, BTEError);
+      Error.captureStackTrace(this, InvalidQueryGraphError);
     }
 
     this.name = name;

--- a/src/query_node_2.js
+++ b/src/query_node_2.js
@@ -190,4 +190,8 @@ module.exports = class QNode {
     hasEquivalentIDs() {
         return !(typeof this.equivalentIDs === 'undefined');
     }
+
+    getEntityCount() {
+        return this.curie ? this.curie.length : 0;
+    }
 };


### PR DESCRIPTION
Edge manager always checks edge entity count before sending off to next layer.  

test query:
```
{
  "message": {
    "query_graph": {
      "edges": {
        "e00": {
          "subject": "n00",
          "object": "n01"
        },
        "e01": {
          "subject": "n01",
          "object": "n02"
        }
      },
      "nodes": {
        "n00": {
          "ids": ["DOID:14330"],
          "categories": ["biolink:Disease"]
        },
        "n01": {
          "categories": ["biolink:NamedThing"]
        },
        "n02": {
          "categories": ["biolink:Disease"]
        }
      }
    }
  }
}
```

response:
```
{
    "message": {
        "query_graph": {
            "edges": {
                "e00": {
                    "subject": "n00",
                    "object": "n01"
                },
                "e01": {
                    "subject": "n01",
                    "object": "n02"
                }
            },
            "nodes": {
                "n00": {
                    "ids": [
                        "DOID:14330"
                    ],
                    "categories": [
                        "biolink:Disease"
                    ]
                },
                "n01": {
                    "categories": [
                        "biolink:NamedThing"
                    ]
                },
                "n02": {
                    "categories": [
                        "biolink:Disease"
                    ]
                }
            }
        },
        "knowledge_graph": {
            "nodes": {},
            "edges": {}
        },
        "results": []
    },
    "status": "501",
    "description": "QueryAborted: Max number of entities exceeded (1000) in 'e01'"
}
```

<img width="591" alt="Screen Shot 2021-10-28 at 7 56 53 PM" src="https://user-images.githubusercontent.com/23092057/139366239-5ea45379-1055-4874-ad81-f1f3303a7e38.png">
