### PR TITLE
feat: support annotated batchSize for ID chunking

### DIFF
--- a/src/qedge2bteedge.js
+++ b/src/qedge2bteedge.js
@@ -164,10 +164,14 @@ module.exports = class QEdge2BTEEdgeHandler {
     if (smartAPIEdge.tags.includes('biothings')) {
       chunksize = 1000;
     }
-    const configuredLimit = config.API_MAX_ID_LIST.find((api) => {
+    let configuredLimit = smartAPIEdge.query_operation.batchSize;
+    let hardLimit = config.API_MAX_ID_LIST.find((api) => {
       return api.id === smartAPIEdge.association.smartapi.id || api.name === smartAPIEdge.association.api_name;
     });
-    chunksize = configuredLimit ? configuredLimit.max : chunksize;
+    // BTE internal configured limit takes precedence over annotated limit
+    chunksize = hardLimit
+      ? hardLimit.max
+      : configuredLimit ? configuredLimit : chunksize;
     if (Object.keys(id_mapping).length > 0) {
       await Promise.all(_.chunk(inputs, chunksize).map(async (chunk) => {
         let blockingSince = Date.now();
@@ -266,10 +270,14 @@ module.exports = class QEdge2BTEEdgeHandler {
     if (smartAPIEdge.tags.includes('biothings')) {
       chunksize = 1000;
     }
-    const configuredLimit = config.API_MAX_ID_LIST.find((api) => {
+    let configuredLimit = smartAPIEdge.query_operation.batchSize;
+    let hardLimit = config.API_MAX_ID_LIST.find((api) => {
       return api.id === smartAPIEdge.association.smartapi.id || api.name === smartAPIEdge.association.api_name;
     });
-    chunksize = configuredLimit ? configuredLimit.max : chunksize;
+    // BTE internal configured limit takes precedence over annotated limit
+    chunksize = hardLimit
+      ? hardLimit.max
+      : configuredLimit ? configuredLimit : chunksize;
     if (Object.keys(id_mapping).length > 0) {
       await Promise.all(_.chunk(inputs, chunksize).map(async (chunk) => {
         let blockingSince = Date.now();


### PR DESCRIPTION
Allow x-bte annotations to annotate `batchSize` in order to set a maximum number of IDs sent in a query. IDs will be chunked with respect to batch size, with BTE-configured per-API maximums taking precedence.

Requires https://github.com/biothings/smartapi-kg.js/pull/43