### PR TITLE
Revert "Limit SEMMEDDB and Targeted Association API's to 100 IDs per query"

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,13 +1,8 @@
 exports.API_MAX_ID_LIST = [
   {
-    id: '1d288b3a3caf75d541ffaae3aab386c8',
-    name: 'BioThings SEMMEDDB API',
-    max: 100,
-  },
-  {
-    id: '978fe380a147a8641caf72320862697b',
-    name: 'Text Mining Targeted Association API',
-    max: 100,
+    id: undefined,
+    name: 'Some nonexistent API',
+    max: 20,
   },
 ];
 


### PR DESCRIPTION
Reverts biothings/bte_trapi_query_graph_handler#60