### PR TITLE
Fix: pass caching parameter to cacheHandler

### DIFF
--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -108,7 +108,7 @@ module.exports = class BatchEdgeQueryHandler {
     await nodeUpdate.setEquivalentIDs(qEdges);
     await this._rmEquivalentDuplicates(qEdges);
     debug('Node Update Success');
-    const cacheHandler = new CacheHandler(qEdges);
+    const cacheHandler = new CacheHandler(qEdges, this.caching);
     const { cachedResults, nonCachedEdges } = await cacheHandler.categorizeEdges(qEdges);
     this.logs = [...this.logs, ...cacheHandler.logs];
     let query_res;

--- a/src/cache_handler.js
+++ b/src/cache_handler.js
@@ -10,7 +10,7 @@ module.exports = class {
     this.qEdges = qEdges;
     this.logs = logs;
     this.cacheEnabled =
-      caching === 'false'
+      caching === false
         ? false
         : process.env.RESULT_CACHING !== 'false'
         ? !(process.env.REDIS_HOST === undefined) && !(process.env.REDIS_PORT === undefined)

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
   }
 
   _createBatchEdgeQueryHandlersForCurrent(currentEdge, kg) {
-    let handler = new BatchEdgeQueryHandler(kg, this.resolveOutputIDs);
+    let handler = new BatchEdgeQueryHandler(kg, this.resolveOutputIDs, {caching: this.options.caching });
     handler.setEdges(currentEdge);
     return handler;
   }


### PR DESCRIPTION
Required for https://github.com/biothings/BioThings_Explorer_TRAPI/pull/350 to work.

During the switchover to the new query logic, the caching query parameter stopped being passed down to the `cacheHandler`. This PR ensures the `cacheHandler` receives and correctly uses that information.