### PR TITLE
Check metakg before query execution and cancel on missing operations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ const InvalidQueryGraphError = require('./exceptions/invalid_query_graph_error')
 const debug = require('debug')('bte:biothings-explorer-trapi:main');
 const Graph = require('./graph/graph');
 const EdgeManager = require('./edge_manager');
+const _ = require('lodash');
+const QEdge2BTEEdgeHandler = require('./qedge2bteedge');
+const LogEntry = require('./log_entry');
 
 exports.InvalidQueryGraphError = InvalidQueryGraphError;
 

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,47 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
     return handler;
   }
 
+  async _edgesSupported(qEdges, kg) {
+    // _.cloneDeep() is resource-intensive but only runs once per query
+    qEdges = _.cloneDeep(qEdges);
+    const manager = new EdgeManager(qEdges);
+    const edgesMissingOps = {};
+    while (manager.getEdgesNotExecuted()) {
+      let current_edge = manager.getNext();
+      const edgeConverter = new QEdge2BTEEdgeHandler([current_edge], kg);
+      const sAPIEdges = edgeConverter.getSmartAPIEdges(current_edge);
+      if (!sAPIEdges.length) {
+        edgesMissingOps[current_edge.qEdge.id] = current_edge.reverse;
+      }
+      // assume results so next edge may be reversed or not
+      current_edge.executed = true;
+      current_edge.object.entity_count = 1;
+      current_edge.subject.entity_count = 1;
+      // this.logs = [...this.logs, ...edgeConverter.logs];
+    }
+
+    const len = Object.keys(edgesMissingOps).length;
+    // this.logs = [...this.logs, ...manager.logs];
+    let edgesToLog = Object.entries(edgesMissingOps).map(([edge, reversed]) => {
+      return reversed
+        ? `(reversed ${edge})`
+        : `(${edge})`;
+    });
+    edgesToLog = edgesToLog.length > 1
+      ? `[${edgesToLog.join(', ')}]`
+      : `${edgesToLog.join(', ')}`
+    if (len > 0) {
+      const terminateLog = `Query Edge${len > 1 ? 's' : ''} ${edgesToLog} ${
+        len > 1 ? 'have' : 'has'
+      } no SmartAPI edges. Your query terminates.`;
+      debug(terminateLog);
+      this.logs.push(new LogEntry('WARNING', null, terminateLog).getLog());
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   async query() {
     this._initializeResponse();
     debug('Start to load metakg.');
@@ -113,6 +154,9 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
     debug('MetaKG successfully loaded!');
     let queryEdges = await this._processQueryGraph(this.queryGraph);
     debug(`(3) All edges created ${JSON.stringify(queryEdges)}`);
+    if (!(await this._edgesSupported(queryEdges, kg))) {
+      return;
+    }
     const manager = new EdgeManager(queryEdges);
     while (manager.getEdgesNotExecuted()) {
       //next available/most efficient edge

--- a/src/qedge2bteedge.js
+++ b/src/qedge2bteedge.js
@@ -31,7 +31,7 @@ module.exports = class QEdge2BTEEdgeHandler {
    * @param {object} kg - SmartAPI Knowledge Graph Object
    * @param {object} qEdge - TRAPI Query Edge Object
    */
-  _getSmartAPIEdges(qEdge, kg = this.kg) {
+  getSmartAPIEdges(qEdge, kg = this.kg) {
     debug(`Subject node is ${qEdge.getSubject().id}`);
     debug(`Object node is ${qEdge.getObject().id}`);
     this.logs.push(
@@ -319,7 +319,7 @@ module.exports = class QEdge2BTEEdgeHandler {
   async convert(qEdges) {
     let bteEdges = [];
     await Promise.all(qEdges.map(async (edge) => {
-      const smartapi_edges = await this._getSmartAPIEdges(edge);
+      const smartapi_edges = await this.getSmartAPIEdges(edge);
       const apis = _.uniq(smartapi_edges.map(api => api.association.api_name));
       debug(`${apis.length} APIs being used:`, JSON.stringify(apis));
       debug(`${smartapi_edges.length} SmartAPI edges are retrieved....`);


### PR DESCRIPTION
*(addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/335, new PR/branch re-created due to broken rebase)*

Original PR here: https://github.com/biothings/bte_trapi_query_graph_handler/pull/66

Query edges are iterated over and checked against the metakg to ensure there are SmartAPI edges that correspond. On each edge iteration, it is assumed that the edge returned results so that the next edge may be reversed as needed (should resolve https://github.com/biothings/bte_trapi_query_graph_handler/pull/66#issuecomment-961482689). 