### PR TITLE
Fix incorrect cache returns between endpoints, and other edge cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "biomedical_id_resolver": "^3.10.0",
         "debug": "^4.3.1",
         "lodash": "^4.17.21",
-        "redis": "^3.1.1"
+        "redis": "^3.1.1",
+        "redis-lock": "^0.1.4"
       },
       "devDependencies": {
         "coveralls": "^3.1.0",
@@ -6742,6 +6743,14 @@
       "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/redis-lock": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/redis-lock/-/redis-lock-0.1.4.tgz",
+      "integrity": "sha512-7/+zu86XVQfJVx1nHTzux5reglDiyUCDwmW7TSlvVezfhH2YLc/Rc8NE0ejQG+8/0lwKzm29/u/4+ogKeLosiA==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/redis-mock": {
@@ -14233,6 +14242,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-lock": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/redis-lock/-/redis-lock-0.1.4.tgz",
+      "integrity": "sha512-7/+zu86XVQfJVx1nHTzux5reglDiyUCDwmW7TSlvVezfhH2YLc/Rc8NE0ejQG+8/0lwKzm29/u/4+ogKeLosiA=="
     },
     "redis-mock": {
       "version": "0.56.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "biomedical_id_resolver": "^3.10.0",
     "debug": "^4.3.1",
     "lodash": "^4.17.21",
-    "redis": "^3.1.1"
+    "redis": "^3.1.1",
+    "redis-lock": "^0.1.4"
   }
 }

--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -108,7 +108,7 @@ module.exports = class BatchEdgeQueryHandler {
     await nodeUpdate.setEquivalentIDs(qEdges);
     await this._rmEquivalentDuplicates(qEdges);
     debug('Node Update Success');
-    const cacheHandler = new CacheHandler(qEdges, this.caching);
+    const cacheHandler = new CacheHandler(qEdges, this.caching, this.kg);
     const { cachedResults, nonCachedEdges } = await cacheHandler.categorizeEdges(qEdges);
     this.logs = [...this.logs, ...cacheHandler.logs];
     let query_res;

--- a/src/cache_handler.js
+++ b/src/cache_handler.js
@@ -34,6 +34,7 @@ module.exports = class {
     for (let i = 0; i < qEdges.length; i++) {
       const hashedEdgeID = this._hashEdgeByKG(qEdges[i].getHashedEdgeRepresentation());
       let cachedResJSON;
+      const unlock = await redisClient.lock('redisLock:' + id);
       try {
         const cachedRes = await redisClient.hgetallAsync(hashedEdgeID);
         cachedResJSON = cachedRes
@@ -44,6 +45,8 @@ module.exports = class {
       } catch (error) {
         cachedResJSON = null;
         debug(`Cache lookup/retrieval failed due to ${error}. Proceeding without cache.`);
+      } finally {
+        unlock();
       }
       if (cachedResJSON) {
         this.logs.push(new LogEntry('DEBUG', null, `BTE find cached results for ${qEdges[i].getID()}`).getLog());

--- a/src/cache_handler.js
+++ b/src/cache_handler.js
@@ -4,10 +4,12 @@ const LogEntry = require('./log_entry');
 const { parentPort } = require('worker_threads');
 const _ = require('lodash');
 const async = require('async');
+const helper = require('./helper');
 
 module.exports = class {
-  constructor(qEdges, caching, logs = []) {
+  constructor(qEdges, caching, kg = undefined, logs = []) {
     this.qEdges = qEdges;
+    this.kg = kg;
     this.logs = logs;
     this.cacheEnabled =
       caching === false
@@ -30,7 +32,7 @@ module.exports = class {
     let nonCachedEdges = [];
     let cachedResults = [];
     for (let i = 0; i < qEdges.length; i++) {
-      const hashedEdgeID = qEdges[i].getHashedEdgeRepresentation();
+      const hashedEdgeID = this._hashEdgeByKG(qEdges[i].getHashedEdgeRepresentation());
       let cachedResJSON;
       try {
         const cachedRes = await redisClient.hgetallAsync(hashedEdgeID);
@@ -85,18 +87,27 @@ module.exports = class {
 
     const returnVal = { ...record };
     returnVal.$edge_metadata = { ...record.$edge_metadata };
-    // replaced after taking out of cahce, so save some memory
+    // replaced after taking out of cache, so save some memory
     returnVal.$edge_metadata.trapi_qEdge_obj = undefined;
     returnVal.$input = copyObjs.$input;
     returnVal.$output = copyObjs.$output;
     return returnVal;
   }
 
+  _hashEdgeByKG(hashedEdgeID) {
+    if (!this.kg) {
+      return hashedEdgeID;
+    }
+    const len = String(this.kg.ops.length);
+    const allIDs = Array.from(new Set(this.kg.ops.map((op) => op.association.smartapi.id))).join('');
+    return new helper()._generateHash(hashedEdgeID + len + allIDs);
+  }
+
   _groupQueryResultsByEdgeID(queryResult) {
     let groupedResult = {};
     queryResult.map((record) => {
       try {
-        const hashedEdgeID = record.$edge_metadata.trapi_qEdge_obj.getHashedEdgeRepresentation();
+        const hashedEdgeID = this._hashEdgeByKG(record.$edge_metadata.trapi_qEdge_obj.getHashedEdgeRepresentation());
         if (!(hashedEdgeID in groupedResult)) {
           groupedResult[hashedEdgeID] = [];
         }
@@ -124,15 +135,18 @@ module.exports = class {
       const hashedEdgeIDs = Array.from(Object.keys(groupedQueryResult));
       debug(`Number of hashed edges: ${hashedEdgeIDs.length}`);
       await async.eachSeries(hashedEdgeIDs, async (id) => {
+        // lock to prevent caching to/reading from actively caching edge
+        const unlock = await redisClient.lock("redisLock:" + id);
+        try {
+          await redisClient.delAsync(id); // prevents weird overwrite edge cases
           await async.eachOfSeries(groupedQueryResult[id], async (edge, index) => {
-            await redisClient.hsetAsync(
-              id,
-              index.toString(),
-              JSON.stringify(edge),
-            );
+            await redisClient.hsetAsync(id, index.toString(), JSON.stringify(edge));
           });
           await redisClient.expireAsync(id, process.env.REDIS_KEY_EXPIRE_TIME || 600);
-        });
+        } finally {
+          unlock(); // release lock whether cache succeeded or not
+        }
+      });
       debug(`Successfully cached (${queryResult.length}) query results.`);
     } catch (error) {
       debug(`Caching failed due to ${error}. This does not terminate the query.`);

--- a/src/cache_handler.js
+++ b/src/cache_handler.js
@@ -34,7 +34,7 @@ module.exports = class {
     for (let i = 0; i < qEdges.length; i++) {
       const hashedEdgeID = this._hashEdgeByKG(qEdges[i].getHashedEdgeRepresentation());
       let cachedResJSON;
-      const unlock = await redisClient.lock('redisLock:' + id);
+      const unlock = await redisClient.lock('redisLock:' + hashedEdgeID);
       try {
         const cachedRes = await redisClient.hgetallAsync(hashedEdgeID);
         cachedResJSON = cachedRes

--- a/src/redis-client.js
+++ b/src/redis-client.js
@@ -1,5 +1,7 @@
 const redis = require('redis');
+const redisLock = require('redis-lock');
 const { promisify } = require('util');
+
 
 let client;
 
@@ -22,6 +24,7 @@ const redisClient =
         hgetallAsync: promisify(client.hgetall).bind(client),
         expireAsync: promisify(client.expire).bind(client),
         delAsync: promisify(client.del).bind(client),
+        lock: promisify(redisLock(client)),
         // hmsetAsync: promisify(client.hmset).bind(client),
         // keysAsync: promisify(client.keys).bind(client),
         // existsAsync: promisify(client.exists).bind(client),


### PR DESCRIPTION
*(addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/353 and https://github.com/biothings/BioThings_Explorer_TRAPI/issues/354)*

- Cache keys now add use hash of unique metakg id's and metakg size for a given query in addition to hashed edge representation
- When saving to or retrieving from cache, an edge-specific lock is acquired, and released when done. This prevents the possibility of multiple queries attempting to cache the same edge, or a query retrieving only a partial cache while another is still caching.