### PR TITLE
fix: :sparkles: check undefined equivalent ids

### DIFF
--- a/src/edge_manager.js
+++ b/src/edge_manager.js
@@ -209,13 +209,15 @@ module.exports = class EdgeManager {
                         //check if array
                         if (Array.isArray(o._dbIDs[prefix])) {
                             o._dbIDs[prefix].forEach((single_alias) => {
-                            if (single_alias.includes(':')) {
-                                //value already has prefix
-                                ids.add(single_alias);
-                            }else{
-                                //concat with prefix
-                                ids.add(prefix + ':' + single_alias);
-                            }
+                                if (single_alias) {
+                                    if (single_alias.includes(':')) {
+                                        //value already has prefix
+                                        ids.add(single_alias);
+                                    }else{
+                                        //concat with prefix
+                                        ids.add(prefix + ':' + single_alias);
+                                    }
+                                }
                             });
                         }else{
                             if (o._dbIDs[prefix].includes(':')) {
@@ -248,13 +250,15 @@ module.exports = class EdgeManager {
                         //check if array
                         if (Array.isArray(o._dbIDs[prefix])) {
                             o._dbIDs[prefix].forEach((single_alias) => {
-                            if (single_alias.includes(':')) {
-                                //value already has prefix
-                                o_ids.add(single_alias);
-                            }else{
-                                //concat with prefix
-                                o_ids.add(prefix + ':' + single_alias);
-                            }
+                                if (single_alias) {
+                                    if (single_alias.includes(':')) {
+                                        //value already has prefix
+                                        o_ids.add(single_alias);
+                                    }else{
+                                        //concat with prefix
+                                        o_ids.add(prefix + ':' + single_alias);
+                                    }
+                                }
                             });
                         }else{
                             if (o._dbIDs[prefix].includes(':')) {

--- a/src/query_execution_edge.js
+++ b/src/query_execution_edge.js
@@ -91,12 +91,14 @@ module.exports = class UpdatedExeEdge {
               //check if array
               if (Array.isArray(o._dbIDs[prefix])) {
                 o._dbIDs[prefix].forEach((single_alias) => {
-                  if (single_alias.includes(':')) {
-                    //value already has prefix
-                    original_aliases.add(single_alias);
-                  }else{
-                    //concat with prefix
-                    original_aliases.add(prefix + ':' + single_alias);
+                  if (single_alias) {
+                    if (single_alias.includes(':')) {
+                      //value already has prefix
+                      original_aliases.add(single_alias);
+                    }else{
+                      //concat with prefix
+                      original_aliases.add(prefix + ':' + single_alias);
+                    }
                   }
                 });
               }else{
@@ -155,12 +157,14 @@ module.exports = class UpdatedExeEdge {
               //check if array
               if (Array.isArray(o._dbIDs[prefix])) {
                 o._dbIDs[prefix].forEach((single_alias) => {
-                  if (single_alias.includes(':')) {
-                    //value already has prefix
-                    original_aliases.add(single_alias);
-                  }else{
-                    //concat with prefix
-                    original_aliases.add(prefix + ':' + single_alias);
+                  if (single_alias) {
+                    if (single_alias.includes(':')) {
+                      //value already has prefix
+                      original_aliases.add(single_alias);
+                    }else{
+                      //concat with prefix
+                      original_aliases.add(prefix + ':' + single_alias);
+                    }
                   }
                 });
               }else{


### PR DESCRIPTION
Add `undefined` check during equivalent ID comparison in execEdge and edgeManager that previously assumed each prefix would have at least one value.  ID resolver returns an object of equivalent IDs  as such { prefix : [...identifier(s)]}, but the need to add this indicates the list of identifiers can sometimes be undefined. 