### PR TITLE
update the BTE infores ID

### DIFF
--- a/src/graph/knowledge_graph.js
+++ b/src/graph/knowledge_graph.js
@@ -69,7 +69,7 @@ module.exports = class KnowledgeGraph {
     let attributes = [
       {
         attribute_type_id: 'biolink:aggregator_knowledge_source',
-        value: ['infores:translator-biothings-explorer'],
+        value: ['infores:biothings-explorer'],
         value_type_id: 'biolink:InformationResource',
       },
     ];


### PR DESCRIPTION
In reviewing the ARAX results from a recent standup query, we observed that some ARAX edges were tagged with both `infores:biothings-explorer` and `infores:translator-biothings-explorer`.  See screenshot:

![image](https://user-images.githubusercontent.com/2635409/145664319-f2e4f4b5-5c6e-4c9a-bffd-1cf5c787df7c.png)

After some [discussion](https://ncatstranslator.slack.com/archives/C014B3JAX36/p1639180774051200?thread_ts=1639171688.048500&cid=C014B3JAX36) with the data modeling team, @sierra-moxon "deprecated `infores:translator-biothings-explorer` and copied over its metadata to `infores:biothings-explorer`".  This PR aligns BTE-added edge attributes with this decision.