### PR TITLE
fix: warn+terminate if edge drops all results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -220,6 +220,18 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
       manager.updateEdgeResults(current_edge);
       //update and filter neighbors
       manager.updateAllOtherEdges(current_edge);
+      // check that any results are kept
+      if (!current_edge.results.length) {
+        debug(`(X) Terminating..."${current_edge.getID()}" got 0 results.`);
+        this.logs.push(
+            new LogEntry(
+                'WARNING',
+                null,
+                `Edge (${current_edge.getID()}) kept 0 results. Your query terminates.`
+            ).getLog()
+        );
+        return;
+    }
       //edge all done
       current_edge.executed = true;
       debug(`(10) Edge successfully queried.`);


### PR DESCRIPTION
Addresses cases where sub-queries return results, but those results aren't kept because they don't match the opposing `qNode` ID(s). 

After updating edge results, check if the edge still has any results and terminate the query if it doesn't, with a warning to the user via TRAPI logs.