### PR TITLE
Infer node categories for nodes with multiple IDs

### DIFF
--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -47,54 +47,111 @@ module.exports = class QueryGraphHandler {
   /**
    * @private
    */
-    async _findNodeCategories(ids) {
-      if (ids.length == 1) {
-        let category = await id_resolver.resolveSRI({
-            unknown: ids
-        });
-        debug(`Query node missing categories...Looking for match...`);
-        if (Object.hasOwnProperty.call(category, ids[0])) {
-            category = category[ids[0]][0]['semanticType'];
-            return ["biolink:" + category];
-        } else {
-            debug(`No category match found for ${JSON.stringify(ids)}.`);
-            return [];
-        }
+  async _findNodeCategories(ids) {
+    const noMatchMessage = `No category match found for ${JSON.stringify(ids)}.`;
+    if (ids.length == 1) {
+      let category = await id_resolver.resolveSRI({
+          unknown: ids
+      });
+      debug(`Query node missing categories...Looking for match...`);
+      if (Object.hasOwnProperty.call(category, ids[0])) {
+          category = category[ids[0]][0]['semanticType'];
+          return ["biolink:" + category];
+      } else {
+          debug(noMatchMessage);
+          this.logs.push(
+            new LogEntry(
+              'ERROR',
+              null,
+              noMatchMessage,
+            ).getLog()
+          );
+          return [];
+      }
     } else {
-      const categories = await id_resolver.resolveSRI({unknown: ids});
-      const commonCategories = _.intersection(
-        ...Object.values(categories)
-        .map(curie => curie[0].semanticTypes)
-        .filter(semanticTypes => !semanticTypes.every(item => item === null))
-        .map(semanticTypes => semanticTypes.map(t => utils.removeBioLinkPrefix(t)))
-        );
-      if (!commonCategories.length) {
-        debug('Given IDs have no common categories. Cannot infer categories.');
-        this.logs.push('Unable to infer multi-ID category (no categories in common)');
-        return [];
-      }
-      const tree = biolink.biolink._biolink_class_tree._objects_in_tree
       try {
-        const mostSpecificCommonCategory = commonCategories.reduce((prev, cat) => {
-          let parent = cat;
-          if (tree[cat]._children.includes(prev)) {
-            return prev;
-          }
-          while (parent) {
-            if (prev === parent || tree[prev]._children.includes(cat)) {
-              return cat;
-            } else if (tree[parent]._children.includes(prev)) {
-              return cat;
+        let finalCategories = [];
+        const tree = biolink.biolink._biolink_class_tree._objects_in_tree
+
+        // get array of all unique categories for all curies
+        const allCategories = [...Object.values(await id_resolver.resolveSRI({unknown: ids}))
+          .map(curie => curie[0].semanticTypes)
+          .filter(semanticTypes => !semanticTypes.every(item => item === null))
+          .map(semanticTypes => semanticTypes.map(t => utils.removeBioLinkPrefix(t)))
+          .reduce((set, arr) => new Set([...set, ...arr]), new Set())];
+
+        if (allCategories.length) {
+          finalCategories.push(allCategories[0]);
+        } else {
+          debug(noMatchMessage);
+          this.logs.push(
+            new LogEntry(
+              'ERROR',
+              null,
+              noMatchMessage,
+            ).getLog()
+          );
+          return [];
+        }
+
+        allCategories.forEach((cat, i) => {
+          const keepSet = new Set();
+          const rmSet = new Set();
+          // check against each currently selected category
+          finalCategories.forEach(selected => {
+            if (tree[selected].is_mixin) { rmSet.add(selected) }
+            if (tree[cat].is_mixin) { rmSet.add(cat) }
+            if (cat === selected) { return keepSet.add(cat) }
+
+            let parent = cat;
+            while (parent) {
+              if (selected === parent || tree[selected]._children.includes(parent)) {
+                rmSet.add(selected);
+                return keepSet.add(cat);
+              }
+              parent = tree[parent]._parent;
             }
-            parent = tree[parent]._parent;
+
+            parent = selected;
+            while (parent) {
+              if (cat === parent || tree[cat]._children.includes(parent)) {
+                rmSet.add(cat)
+                return keepSet.add(selected);
+              }
+              parent = tree[parent]._parent;
+            }
+            // add both if neither is ancestor of the other
+            keepSet.add(cat).add(selected);
+          });
+          finalCategories = [...keepSet].filter(cat => !rmSet.has(cat));
+          // in event no categories are kept (due to mixin shenanigans/etc)
+          if (!finalCategories.length && i < (allCategories.length - 1)) {
+            finalCategories = [allCategories[i + 1]];
           }
-          return prev;
-        }, commonCategories[0]);
-        return ["biolink:" + mostSpecificCommonCategory];
+        });
+        if (!finalCategories.length) {
+          debug(noMatchMessage);
+          this.logs.push(
+            new LogEntry(
+              'ERROR',
+              null,
+              noMatchMessage,
+            ).getLog()
+          );
+        }
+        return [...finalCategories].map(cat => 'biolink:' + cat);
       } catch (error) {
-        debug(`Unable to retrieve categories due to error ${error}`);
-        return [];
-      }
+          const errorMessage = `Unable to retrieve categories due to error ${error}`;
+          debug(errorMessage);
+          this.logs.push(
+            new LogEntry(
+              'ERROR',
+              null,
+              errorMessage,
+            ).getLog()
+          );
+          return [];
+        }
     }
   }
 

--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -176,7 +176,9 @@ module.exports = class QueryGraphHandler {
             new LogEntry(
             'DEBUG',
             null,
-            `Assigned missing node ID category: ${JSON.stringify(this.queryGraph.nodes[node_id])}`).getLog(),
+            `Node (${node_id}) missing category. Assigned categor${category.length > 1 ? 'ies' : 'y'} [${category.join(', ')}] inferred from id${this.queryGraph.nodes[node_id].ids.length > 1 ? 's' : ''} [${this.queryGraph.nodes[node_id].ids.join(', ')}]`,
+            // `Assigned missing node ID category: ${JSON.stringify(this.queryGraph.nodes[node_id])}`).getLog(),
+            ).getLog()
           );
           nodes[node_id] = new QNode(node_id, this.queryGraph.nodes[node_id]);
         }else{


### PR DESCRIPTION
*(addresses biothings/BioThings_Explorer_TRAPI/issues/406)*

In cases with multiple IDs and no node category, categories are retrieved for each ID, and the "most specific" category common to all IDs is chosen.

A few questions remain open regarding this implementation, tagging @andrewsu @colleenXu to comment:

- Currently, this implementation fails if there are no common categories across all IDs. Should categories which are not common to all IDs be included? 
- If there are common IDs of the same 'level' within the tree, only one will be chosen. If such a case is presented, should all common IDs of the same 'level' be kept, provided they are both equally the 'most specific' category? (E.g. `b` and `c` below, assuming all are common BioLink classes and `b` and `c` have no children)
```
a
├── b
└── c
```
- One more unlikely case: In the tree below, assume all nodes are common BioLink classes and that `b` and `d` both have no children. Should only `d` be kept, as it's at a lower 'level' than `b` (and therefore 'more' specific), or should both `d` and `b` be kept because they are both the 'most specific' of their individual branches? Currently, this implementation does the former. 
```
a
├── b
└── c
    └── d
```

*Note: in the above examples, the placeholder letters represent BioLink classes within subsets of the BioLink class hierarchy, such as `biolink:PhenotypicFeature`*