### PR TITLE
Support tracking timed-out/skipped APIs per-query

### DIFF
--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -39,9 +39,9 @@ module.exports = class BatchEdgeQueryHandler {
   /**
    * @private
    */
-  async _queryBTEEdges(bteEdges) {
+  async _queryBTEEdges(bteEdges, unavailableAPIs = {}) {
     let executor = new call_api(bteEdges);
-    const res = await executor.query(this.resolveOutputIDs);
+    const res = await executor.query(this.resolveOutputIDs, unavailableAPIs);
     this.logs = [...this.logs, ...executor.logs];
     return res;
   }
@@ -99,7 +99,7 @@ module.exports = class BatchEdgeQueryHandler {
     });
   }
 
-  async query(qEdges) {
+  async query(qEdges, unavailableAPIs = {}) {
     debug('Node Update Start');
     //it's now a single edge but convert to arr to simplify refactoring
     qEdges = Array.isArray(qEdges) ? qEdges : [qEdges];
@@ -129,7 +129,7 @@ module.exports = class BatchEdgeQueryHandler {
       }
       const expanded_bteEdges = this._expandBTEEdges(bteEdges);
       debug('Start to query BTEEdges....');
-      query_res = await this._queryBTEEdges(expanded_bteEdges);
+      query_res = await this._queryBTEEdges(expanded_bteEdges, unavailableAPIs);
       debug('BTEEdges are successfully queried....');
       debug(`Filtering out any "undefined" items in (${query_res.length}) results`);
       query_res = query_res.filter((res) => res !== undefined);


### PR DESCRIPTION
*(addresses biothings/BioThings_Explorer_TRAPI/issues/392)*

Adds a new variable to track of APIs that were unavailable and how many times they were skipped, and logs these APIs as warnings when execution completes. APIs are only marked unavailable during the handling of a given query -- two simultaneous queries to BTE will independently track which APIs are considered unavailable.

Required for biothings/call-apis.js/pull/46