### PR TITLE
Infer qNode categories and add to user-defined categories where appropriate 

### DIFF
--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -186,14 +186,18 @@ module.exports = class QueryGraphHandler {
               new LogEntry(
                 'DEBUG',
                 null,
-                `${
-                  (typeof userAssignedCategories !== 'undefined' && userAssignedCategories.length)
-                    ? `User-assigned categor${userAssignedCategories.length === 1 ? 'y' : 'ies'} [${userAssignedCategories.join(', ')}] augmented with`
+                [
+                  `Node ${qNodeID} `,
+                  `with id${this.queryGraph.nodes[qNodeID].ids.length > 1 ? 's' : ''} `,
+                  ``,
+                  `${
+                    typeof userAssignedCategories !== 'undefined' && userAssignedCategories.length
+                    ? `and categor${userAssignedCategories.length === 1 ? 'y' : 'ies'} [${userAssignedCategories.join(', ')}] augmented with`
                     : `Assigned`
-                } categor${categories.length > 1 ? 'ies' : 'y'} [${categories.join(', ')}] inferred from id${
-                  this.queryGraph.nodes[qNodeID].ids.length > 1 ? 's' : ''
-                } [${this.queryGraph.nodes[qNodeID].ids.join(', ')}]`,
-                // `Assigned missing node ID category: ${JSON.stringify(this.queryGraph.nodes[qNodeID])}`).getLog(),
+                  } `,
+                  `inferred categor${categories.length > 1 ? 'ies' : 'y'} `,
+                  `[${categories.join(', ')}]`
+                ].join('')
               ).getLog(),
             );
           }


### PR DESCRIPTION
*(addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/418)*

Leveraging https://github.com/biothings/bte_trapi_query_graph_handler/pull/91, QNode Categories are inferred regardless of user-defined categories. Any categories inferred that were not a part of user-defined categories are added to qNode categories, without removing user-defined categories. As a result, user-defined categories remain wholly intact, and are not checked for validity, however additional valid categories are added, should they exist.

This behavior is logged according to the situation:
- No user categories: 'Assigned categories [] inferred from ids []'
- User categories and new inferred: 'User-assigned categories [] augmented with categories [] inferred from ids []'
- User categories and no new inferred: no log

Useful queries to test this behavior:

<details>
<summary>No category provided</summary>

```
{
  "message": {
    "query_graph": {
      "edges": {
        "e01": {
          "object": "n1",
          "subject": "n0",
          "predicates": [
            "biolink:affects_response_to"
          ]
        }
      },
      "nodes": {
        "n0": {
          "ids": [
            "NCBIGene:23221"
          ]
        },
        "n1": {
          "categories": [
            "biolink:SmallMolecule"
          ]
        }
      }
    }
  }
}
```

</details>

<details>
<summary>Category provided, but additional category available</summary>

```
{
  "message": {
    "query_graph": {
      "nodes": {
        "n0": {
          "ids": [
            "CHEBI:41879"
          ],
          "categories": [
            "biolink:ChemicalEntity"
          ],
          "name": "Dexamethasone"
        },
        "n1": {
          "categories": [
            "biolink:DiseaseOrPhenotypicFeature"
          ]
        }
      },
      "edges": {
        "e0": {
          "subject": "n0",
          "object": "n1",
          "predicates": [
            "biolink:treats",
            "biolink:has_real_world_evidence_of_association_with"
          ]
        }
      }
    }
  }
}
```

</details>

<details>
<summary>Category provided, no additional categories found</summary>

```
{
  "message": {
    "query_graph": {
      "edges": {
        "e01": {
          "object": "n0",
          "subject": "n1",
          "predicates": [
            "biolink:entity_negatively_regulates_entity"
          ]
        },
        "e02": {
          "object": "n1",
          "subject": "n2",
          "predicates": [
            "biolink:increases_abundance_of",
            "biolink:increases_expression_of",
            "biolink:increases_stability_of",
            "biolink:increases_uptake_of",
            "biolink:decreases_degradation_of",
            "biolink:increases_secretion_of",
            "biolink:increases_metabolic_processing_of",
            "biolink:increases_folding_of",
            "biolink:increases_localization_of",
            "biolink:increases_synthesis_of",
            "biolink:increases_response_to",
            "biolink:increases_splicing_of",
            "biolink:increases_mutation_rate_of",
            "biolink:increases_transport_of",
            "biolink:increases_activity_of",
            "biolink:increases_molecular_modification_of",
            "biolink:increases_molecular_interaction"
          ]
        }
      },
      "nodes": {
        "n0": {
          "ids": [
            "NCBIGene:23221"
          ],
          "categories": [
            "biolink:Gene"
          ]
        },
        "n1": {
          "categories": [
            "biolink:Gene"
          ]
        },
        "n2": {
          "categories": [
            "biolink:SmallMolecule"
          ]
        }
      }
    }
  }
}
```

</details>