### PR TITLE
Include configured edge attributes in record hash

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,5 +17,9 @@ exports.API_BATCH_SIZE = [
   },
 ];
 
-//max node IDs an edge with no other IDs can have
+// max node IDs an edge with no other IDs can have
 exports.ENTITY_MAX = 1000
+
+exports.EDGE_ATTRIBUTES_USED_IN_RECORD_HASH = [
+  "biolink:has_disease_context",
+];

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,11 @@ exports.API_BATCH_SIZE = [
     name: 'Multiomics Wellness KP API',
     max: 100,
   },
+  {
+    id: 'adf20dd6ff23dfe18e8e012bde686e31',
+    name: 'Multiomics BigGIM-DrugResponse KP API',
+    max: 100,
+  },
 ];
 
 // max node IDs an edge with no other IDs can have
@@ -22,4 +27,5 @@ exports.ENTITY_MAX = 1000
 
 exports.EDGE_ATTRIBUTES_USED_IN_RECORD_HASH = [
   "biolink:has_disease_context",
+  "biolink:GeneToDrugAssociation",
 ];

--- a/src/helper.js
+++ b/src/helper.js
@@ -82,11 +82,11 @@ module.exports = class QueryGraphHelper {
 
   _getConfiguredEdgeAttributesForHash(record) {
     return this._getEdgeAttributes(record)
-      .filter((record) => {
-        return config.EDGE_ATTRIBUTES_USED_IN_RECORD_HASH.includes(record.attribute_type_id);
+      .filter((attribute) => {
+        return config.EDGE_ATTRIBUTES_USED_IN_RECORD_HASH.includes(attribute.attribute_type_id);
       })
       .reduce((acc, attribute) => {
-        return [acc, ...`${attribute.attribute_type_id}:${attribute.value}`];
+        return [...acc, `${attribute.attribute_type_id}:${attribute.value}`];
       }, [])
       .join(',');
   }

--- a/src/helper.js
+++ b/src/helper.js
@@ -75,26 +75,30 @@ module.exports = class QueryGraphHelper {
       this._getOutputCurie(record),
       this._getAPI(record),
       this._getSource(record),
-      this._getConfiguredEdgeAttributesForHash(record)
+      this._getConfiguredEdgeAttributesForHash(record),
     ];
     return this._generateHash(edgeMetaData.join('-'));
   }
 
   _getConfiguredEdgeAttributesForHash(record) {
-    return this._getEdgeAttributes(record).filter((record) => {
-      return config.EDGE_ATTRIBUTES_USED_IN_RECORD_HASH.includes(record.attribute_type_id);
-    }).reduce((acc, attribute) => {
-      return `${acc},${attribute.attribute_type_id}:${attribute.value}`
-    }, '');
+    return this._getEdgeAttributes(record)
+      .filter((record) => {
+        return config.EDGE_ATTRIBUTES_USED_IN_RECORD_HASH.includes(record.attribute_type_id);
+      })
+      .reduce((acc, attribute) => {
+        return [acc, ...`${attribute.attribute_type_id}:${attribute.value}`];
+      }, [])
+      .join(',');
   }
 
   _getEdgeAttributes(record) {
     return record['edge-attributes']
       ? record['edge-attributes'].reduce((arr, attribute) => {
-        return attribute.attributes
-          ? arr.push(attribute, ...this._getEdgeAttributes(attribute))
-          : arr.push(attribute);
-      }, [])
+          attribute.attributes
+            ? arr.push(attribute, ...this._getEdgeAttributes(attribute))
+            : arr.push(attribute);
+          return arr;
+        }, [])
       : [];
   }
 
@@ -171,7 +175,6 @@ module.exports = class QueryGraphHelper {
       return null;
     }
   }
-
 
   _getOutputAttributes(record) {
     try {


### PR DESCRIPTION
*(Addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/407)*

Creates a new variable in `config.js` which allows an array of edge-attribute type IDs to be specified, which will then be included in the record hash using the format `attribute_type_id:value`.

Note that this PR has been tested to confirm it doesn't break anything and does change the resultant record hashes, but has not been tested with an edge attribute to cause additional edge splitting.