### PR TITLE
Fix initialQNodeIDToMatch selection

### DIFF
--- a/__test__/integration/QueryResult.test.js
+++ b/__test__/integration/QueryResult.test.js
@@ -1423,7 +1423,7 @@ describe('Testing QueryResults Module', () => {
         expect(JSON.stringify(resultsOuter)).toEqual(JSON.stringify(resultsInner));
       });
     });
-      
+
     describe('query graph: →', () => {
       test('should get 1 result with record: →', () => {
         const queryResult = new QueryResult();
@@ -1677,7 +1677,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[0]).toHaveProperty('score');
       });
-      
+
       test('should get 2 results with records: >-', () => {
         const queryResult = new QueryResult();
         queryResult.update({
@@ -1710,7 +1710,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[1]).toHaveProperty('score');
       });
-      
+
       test('should get 4 results with records: ><', () => {
         const queryResult = new QueryResult();
         queryResult.update({
@@ -1759,7 +1759,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[3]).toHaveProperty('score');
       });
-      
+
       test('should get 2 results with records: >< (is_set for n0)', () => {
         const queryResult = new QueryResult();
         queryResult.update({
@@ -1792,7 +1792,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[1]).toHaveProperty('score');
       });
-      
+
       test('should get 4 results with records: >< (is_set for n1)', () => {
         const queryResult = new QueryResult();
         queryResult.update({
@@ -1908,7 +1908,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[1]).toHaveProperty('score');
       });
-      
+
       // TODO: Do we want to test for removing duplicates?
       test('should get 1 result with records: ⇉⇉ (duplicates)', () => {
         const queryResult = new QueryResult();
@@ -1934,7 +1934,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[0]).toHaveProperty('score');
       });
-      
+
       test('should get 2 results with records: -<', () => {
         const queryResult = new QueryResult();
         queryResult.update({
@@ -1967,7 +1967,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[1]).toHaveProperty('score');
       });
-      
+
       test('should get 1 result with records: →← (directionality does not match query graph)', () => {
         const queryResult = new QueryResult();
         queryResult.update({
@@ -1993,7 +1993,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[0]).toHaveProperty('score');
       });
 
-      
+
       test('should get 5k results when e0 has 100 records (50 connected, 50 not), and e1 has 10k (5k connected, 5k not)', () => {
         /**
          * This test is intended to assess performance when handling a larger number of records.
@@ -2159,7 +2159,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[1]).toHaveProperty('score');
       });
-      
+
       test('should get 1 result when e0 has 1 record, and e1 has 50k + 1 (1 connected, 50k not)', () => {
         /**
          * n0 -e0-> n1 -e1-> n2
@@ -2277,7 +2277,7 @@ describe('Testing QueryResults Module', () => {
         ]);
         expect(results[0]).toHaveProperty('score');
       });
-      
+
       /*
       describe('test large numbers of records', () => {
         // This group of tests is commented out, b/c they're too slow for regular testing.
@@ -2390,7 +2390,7 @@ describe('Testing QueryResults Module', () => {
           ]);
           expect(results[1]).toHaveProperty('score');
         });
-        
+
         test('should get 50k results when e0 has 1k records (500 connected, 500 not), and e1 has 100k (50k connected, 50k not)', () => {
           // n0 -e0-> n1 -e1-> n2
           //
@@ -3414,5 +3414,88 @@ describe('Testing QueryResults Module', () => {
 ////      });
 //    });
 
+  });
+
+  describe('Graph structure', () => {
+    describe('Initial QNode ID selection', () => {
+      const exampleRecordsByQEdgeID = {
+        e0: {
+          connected_to: ['e1', 'e2'],
+          records: [{
+            $edge_metadata: {
+              trapi_qEdge_obj: {
+                isReversed() { return false; },
+                getSubject() {
+                  return {
+                    getID() { return 'n2' }
+                  }
+                },
+                getObject() {
+                  return {
+                    getID() { return 'n1' }
+                  };
+                },
+              }
+            }
+          }]
+        },
+        e1: {
+          connected_to: ['e0'],
+          records: [{
+            $edge_metadata: {
+              trapi_qEdge_obj: {
+                isReversed() { return false; },
+                getSubject() {
+                  return {
+                    getID() { return 'n2' }
+                  }
+                },
+                getObject() {
+                  return {
+                    getID() { return 'n3' }
+                  };
+                },
+              }
+            }
+          }]
+        },
+        e2: {
+          connected_to: ['e0'],
+          records: [{
+            $edge_metadata: {
+              trapi_qEdge_obj: {
+                isReversed() { return false; },
+                getSubject() {
+                  return {
+                    getID() { return 'n0' }
+                  }
+                },
+                getObject() {
+                  return {
+                    getID() { return 'n1' }
+                  };
+                },
+              }
+            }
+          }]
+        },
+
+      }
+
+      test('Should select leaf node', () => {
+        const queryResult = new QueryResult();
+        const [initialNode, initialEdge] = queryResult._getInitialQNodeIDToMatch(exampleRecordsByQEdgeID);
+        expect(initialNode).toEqual('n3');
+        expect(initialEdge).toEqual('e1');
+      });
+      test('Should select leaf node with fewest records on associated edge', () => {
+        const queryResult = new QueryResult();
+        const example = cloneDeep(exampleRecordsByQEdgeID);
+        example.e1.records.push({fake: true});
+        const [initialNode, initialEdge] = queryResult._getInitialQNodeIDToMatch(example);
+        expect(initialNode).toEqual('n0');
+        expect(initialEdge).toEqual('e2');
+      });
+    });
   });
 });

--- a/src/query_results.js
+++ b/src/query_results.js
@@ -272,7 +272,7 @@ module.exports = class TrapiResultsAssembler {
     debug(`Nodes with "is_set": ${JSON.stringify([...qNodeIDsWithIsSet])}`)
 
     // find a QNode having only one QEdge to use as the root node for tree traversal
-    let [initialQNodeIDToMatch, initialQEdgeID] = this._getInitialPairs(recordsByQEdgeID)[0];
+    let [initialQNodeIDToMatch, initialQEdgeID] = this._getValidInitialPairs(recordsByQEdgeID)[0];
 
     debug(`initialQEdgeID: ${initialQEdgeID}, initialQNodeIDToMatch: ${initialQNodeIDToMatch}`);
 

--- a/src/query_results.js
+++ b/src/query_results.js
@@ -240,42 +240,32 @@ module.exports = class TrapiResultsAssembler {
     debug(`Nodes with "is_set": ${JSON.stringify([...qNodeIDsWithIsSet])}`)
 
     // find a QNode having only one QEdge to use as the root node for tree traversal
-    let initialQEdgeID, initialQNodeIDToMatch;
-    toPairs(recordsByQEdgeID).some(([queryEdgeID, {connected_to, records}]) => {
-      const inputQNodeID = helper._getInputQueryNodeID(records[0]);
-      const outputQNodeID = helper._getOutputQueryNodeID(records[0]);
 
-      if (connected_to.length === 0) {
-        initialQEdgeID = queryEdgeID;
-        initialQNodeIDToMatch = inputQNodeID;
-      } else {
-        connected_to.some((c) => {
-          const nextEdge = recordsByQEdgeID[c];
-          const inputQNodeID_1 = helper._getInputQueryNodeID(nextEdge.records[0]);
-          const outputQNodeID_1 = helper._getOutputQueryNodeID(nextEdge.records[0]);
-          if (!initialQEdgeID) {
-            if ([inputQNodeID_1, outputQNodeID_1].indexOf(inputQNodeID) === -1) {
-              initialQEdgeID = queryEdgeID;
-              initialQNodeIDToMatch = inputQNodeID;
-
-              // like calling break in a loop
-              return true;
-            } else if ([outputQNodeID_1, outputQNodeID_1].indexOf(outputQNodeID) === -1) {
-              initialQEdgeID = queryEdgeID;
-              initialQNodeIDToMatch = outputQNodeID;
-
-              // like calling break in a loop
-              return true;
-            }
+    // qNodeID: set{qEdgeID} for node: edges using node
+    const qNodeEdgeCounts = toPairs(recordsByQEdgeID).reduce(
+      (qNodeCounts, [queryEdgeID, { connected_to, records }]) => {
+        [
+          helper._getInputQueryNodeID(records[0]),
+          helper._getOutputQueryNodeID(records[0])
+        ].forEach((qNodeID) => {
+          if (!qNodeCounts[qNodeID]) {
+            qNodeCounts[qNodeID] = new Set();
           }
+          qNodeCounts[qNodeID].add(queryEdgeID);
         });
+        return qNodeCounts;
+      },
+      {},
+    );
+    // qNodeID: qEdgeID for valid 'leaf' nodes, sorted by # records ascending
+    const validNodes = toPairs(qNodeEdgeCounts)
+      .filter(([qNodeID, qEdgeIDs]) => qEdgeIDs.size < 2)
+      .map(([qNodeID, qEdgeIDs]) => [qNodeID, [...qEdgeIDs][0]])
+      .sort(([qNodeID_0, qEdgeID_0], [qNodeID_1, qEdgeID_1]) => {
+        return recordsByQEdgeID[qEdgeID_0].records.length - recordsByQEdgeID[qEdgeID_1].records.length;
+      });
 
-        if (initialQEdgeID) {
-          // like calling break in a loop
-          return true;
-        }
-      }
-    });
+    let [initialQNodeIDToMatch, initialQEdgeID] = validNodes[0];
 
     debug(`initialQEdgeID: ${initialQEdgeID}, initialQNodeIDToMatch: ${initialQNodeIDToMatch}`);
 


### PR DESCRIPTION
*(fixes https://github.com/biothings/BioThings_Explorer_TRAPI/issues/430)*

Rewrites code for selecting `initialQNodeIDToMatch`/`initialQEdgeID`, operating under a couple assumptions:

- The initial QNode must be a leaf, i.e. it must be referenced by only one edge.
- The best initial QEdge has the fewest records associated.
- The most efficient method of determining a node is a leaf is by just counting its occurrences in the graph edges

This PR has been tested in the issue's test case, and passes the package tests, but stands to be tested on dev prior to merging/deployment.