### PR TITLE
Handle null response from SRI normalizer

### DIFF
--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -54,7 +54,7 @@ module.exports = class QueryGraphHandler {
           unknown: curies
       });
       debug(`Query node missing categories...Looking for match...`);
-      if (Object.hasOwnProperty.call(category, curies[0])) {
+      if (Object.hasOwnProperty.call(category, curies[0]) && category[curies[0]][0]['semanticType']) {
           category = category[curies[0]][0]['semanticType'];
           return ["biolink:" + category];
       } else {


### PR DESCRIPTION
*(Fixes biothings/BioThings_Explorer_TRAPI/issues/440)*

In some cases, node normalization returns `null` for a given curie. This handles those cases by not adding null categories when they are received.