### PR TITLE
Make Additional Attributes into an array

### DIFF
--- a/src/graph/kg_edge.js
+++ b/src/graph/kg_edge.js
@@ -60,6 +60,11 @@ module.exports = class KGEdge {
   }
 
   addAdditionalAttributes(name, value) {
-    this.attributes[name] = value;
+    if (!(name in this.attributes)) {
+      this.attributes[name] = [value];
+    } 
+    else {
+      this.attributes[name] = [...this.attributes[name], value]
+    }
   }
 };

--- a/src/graph/kg_edge.js
+++ b/src/graph/kg_edge.js
@@ -61,10 +61,8 @@ module.exports = class KGEdge {
 
   addAdditionalAttributes(name, value) {
     if (!(name in this.attributes)) {
-      this.attributes[name] = [value];
+      this.attributes[name] = new Set();
     } 
-    else {
-      this.attributes[name] = [...this.attributes[name], value]
-    }
+    this.attributes[name].add(value)
   }
 };

--- a/src/graph/kg_edge.js
+++ b/src/graph/kg_edge.js
@@ -62,7 +62,12 @@ module.exports = class KGEdge {
   addAdditionalAttributes(name, value) {
     if (!(name in this.attributes)) {
       this.attributes[name] = new Set();
-    } 
-    this.attributes[name].add(value)
+    }
+    if (!Array.isArray(value)) {
+      value = [value];
+    }
+    value.map((item) => {
+      this.attributes[name].add(item)
+    })
   }
 };

--- a/src/graph/knowledge_graph.js
+++ b/src/graph/knowledge_graph.js
@@ -123,7 +123,7 @@ module.exports = class KnowledgeGraph {
       for (const key in kgEdge.attributes) {
         attributes.push({
           attribute_type_id: key,
-          value: kgEdge.attributes[key],
+          value: Array.from(kgEdge.attributes[key]),
           //value_type_id: 'bts:' + key,
         });
       }

--- a/src/graph/knowledge_graph.js
+++ b/src/graph/knowledge_graph.js
@@ -166,7 +166,7 @@ module.exports = class KnowledgeGraph {
       for (const key in kgEdge.attributes) {
         attributes.push({
           attribute_type_id: key,
-          value: kgEdge.attributes[key],
+          value: Array.from(kgEdge.attributes[key]),
           //value_type_id: 'bts:' + key,
         });
       }


### PR DESCRIPTION
This PR is meant to solve [this issue](https://github.com/biothings/BioThings_Explorer_TRAPI/issues/463). I currently have made all additional attributes to an array, even if they only have one value similar to biolink attributes such as the ones in this screenshot. The behavior could be changed to make single values into normal values rather than single value arrays.
![image](https://user-images.githubusercontent.com/16053597/178041745-39fbbd30-7de8-4e97-aab9-5330a2065c83.png)
