### PR TITLE
Log when entry in config list is not in smartapi registry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,14 +35,14 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
     this.options.apiList && this.findUnregisteredApi();
   }
 
-  findUnregisteredApi() {
+  async findUnregisteredApi() {
     const configListApis = this.options.apiList['include']
-    const smartapiRegistry = require('./smartapi_specs.json')['hits']
+    const smartapiRegistry = await fs.readFile(this.path)
     const smartapiIds = []
 
-    smartapiRegistry.forEach(smartapiRegistration => smartapiIds.push(smartapiRegistration['_id']));
+    JSON.parse(smartapiRegistry)['hits'].forEach(smartapiRegistration => smartapiIds.push(smartapiRegistration['_id']));
     configListApis.forEach(configListApi => {
-      if(smartapiIds.includes(configListApi['id']) == false) {
+      if(smartapiIds.includes(configListApi['id']) === false) {
         debug(`${configListApi['name']} not found in smartapi registry`);
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
       typeof this.options.enableIDResolution === 'undefined' ? true : this.options.enableIDResolution;
     this.path = smartAPIPath || path.resolve(__dirname, './smartapi_specs.json');
     this.predicatePath = predicatesPath || path.resolve(__dirname, './predicates.json');
-    this.findUnregisteredApi();
+    this.options.apiList && this.findUnregisteredApi();
   }
 
   findUnregisteredApi() {
@@ -45,7 +45,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
       if(smartapiIds.includes(configListApi['id']) == false) {
         debug(`${configListApi['name']} not found in smartapi registry`);
       }
-    })
+    });
   }
 
   _loadMetaKG() {

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,20 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
       typeof this.options.enableIDResolution === 'undefined' ? true : this.options.enableIDResolution;
     this.path = smartAPIPath || path.resolve(__dirname, './smartapi_specs.json');
     this.predicatePath = predicatesPath || path.resolve(__dirname, './predicates.json');
+    this.findUnregisteredApi();
+  }
+
+  findUnregisteredApi() {
+    const configListApis = this.options.apiList['include']
+    const smartapiRegistry = require('./smartapi_specs.json')['hits']
+    const smartapiIds = []
+
+    smartapiRegistry.forEach(smartapiRegistration => smartapiIds.push(smartapiRegistration['_id']));
+    configListApis.forEach(configListApi => {
+      if(smartapiIds.includes(configListApi['id']) == false) {
+        debug(`${configListApi['name']} not found in smartapi registry`);
+      }
+    })
   }
 
   _loadMetaKG() {


### PR DESCRIPTION
Solves [issue #428](https://github.com/biothings/BioThings_Explorer_TRAPI/issues/428) by logging to the console when a smartapi ID in the config list isn't found in the registry data. 