### PR TITLE
use canonical direction

### DIFF
--- a/src/biolink.js
+++ b/src/biolink.js
@@ -13,6 +13,19 @@ class BioLinkModel {
     return BioLinkModel.instance;
   }
 
+  isCanonical(predicate) {
+    if (typeof predicate === 'string') {
+      if (predicate in this.biolink.slotTree.objects) {
+        console.log("slttree")
+        console.log(this.biolink.slotTree.objects[predicate])
+        if (this.biolink.slotTree.objects[predicate].canonical_predicate !== true) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   reverse(predicate) {
     if (typeof predicate === 'string') {
       if (predicate in this.biolink.slotTree.objects) {

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -1,6 +1,7 @@
 const kg_edge = require('./kg_edge');
 const kg_node = require('./kg_node');
 const debug = require('debug')('bte:biothings-explorer-trapi:Graph');
+const biolink = require('../biolink')
 
 module.exports = class BTEGraph {
   constructor() {
@@ -89,6 +90,18 @@ module.exports = class BTEGraph {
       .filter((recordHash) => !resultsBoundEdges.has(recordHash));
     edgesToDelete.forEach((unusedRecordHash) => delete this.edges[unusedRecordHash]);
     debug(`pruned ${nodesToDelete.length} nodes and ${edgesToDelete.length} edges from BTEGraph.`);
+  }
+
+  useCanonicalDirection() {
+    Object.keys(this.edges).map(edgeID => {
+      const predicate = this.edges[edgeID].predicate.substring(8)
+      if (!biolink.isCanonical(predicate)) {
+        let temp = this.edges[edgeID].subject
+        this.edges[edgeID].subject = this.edges[edgeID].object
+        this.edges[edgeID].object = temp
+        this.edges[edgeID].predicate = 'biolink:' + biolink.reverse(predicate)
+      }
+    })
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -769,6 +769,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
     this.logs = [...this.logs, ...this.trapiResultsAssembler.logs];
     // prune bteGraph
     this.bteGraph.prune(this.trapiResultsAssembler.getResults());
+    this.bteGraph.useCanonicalDirection()
     this.bteGraph.notify();
     // finishing logs
     this.createSummaryLog(this.logs).forEach((log) => this.logs.push(log));


### PR DESCRIPTION
Uses canonical direction instead of query direction as stated by [this issue](https://github.com/biothings/BioThings_Explorer_TRAPI/issues/476). Depends on [this PR](https://github.com/biothings/biolink-model.js/pull/30) on biolink-model.js