### PR TITLE
Handle null predicates, ids, and categories

### DIFF
--- a/__test__/integration/QueryGraphHandler.test.js
+++ b/__test__/integration/QueryGraphHandler.test.js
@@ -169,6 +169,39 @@ describe("Testing QueryGraphHandler Module", () => {
         }
     };
 
+    const QueryWithNullValues = {
+        nodes: {
+            n0: {
+              ...disease_entity_node,
+              categories: null
+            },
+            n1: { 
+              ...gene_class_node,
+              ids: null
+            },
+        },
+        edges: {
+            e01: {
+                subject: "n0",
+                object: "n1"
+            }
+        }
+    };
+
+    const QueryWithNullPredicate = {
+        nodes: {
+            n0: disease_entity_node,
+            n1: gene_class_node,
+        },
+        edges: {
+            e01: {
+                subject: "n0",
+                object: "n1",
+                predicate: null
+            }
+        }
+    };
+
     describe("test _storeNodes function", () => {
 
         test("test if storeNodes with one hop query", async () => {
@@ -223,15 +256,28 @@ describe("Testing QueryGraphHandler Module", () => {
     describe("test cycle/duplicate edge detection for query graphs", () => {
       test("Duplicate Edge Graph #1", async () => {
         const handler = new QueryGraphHandler(QueryWithDuplicateEdge1)
-        expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
+        await expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
       })
       test("Query Graph Cycle #1", async () => {
         const handler = new QueryGraphHandler(QueryWithCycle1)
-        expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
+        await expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
       })
       test("Query Graph Cycle #2", async () => {
         const handler = new QueryGraphHandler(QueryWithCycle2)
-        expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
+        await expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
+      })
+    })
+
+    describe("test chandling of null ids / categories / predicates", () => {
+      test("Null id/categories graph", async () => {
+        const handler = new QueryGraphHandler(QueryWithNullValues)
+        await expect(handler.calculateEdges()).resolves.not.toThrow()
+      })
+      test("Null predicate graph", async () => {
+        const handler = new QueryGraphHandler(QueryWithNullPredicate)
+        const edges = await handler.calculateEdges()
+        // if this is undefined (not null) then smartapi-kg treats as if the field doesn't exist (desired behavior)
+        expect(edges[0][0].getPredicate()).toBe(undefined)
       })
     })
 });

--- a/__test__/integration/QueryGraphHandler.test.js
+++ b/__test__/integration/QueryGraphHandler.test.js
@@ -202,6 +202,25 @@ describe("Testing QueryGraphHandler Module", () => {
         }
     };
 
+    const QueryWithNullIds = {
+      nodes: {
+            n0: {
+              ...disease_entity_node,
+              ids: []
+            },
+            n1: { 
+              ...gene_class_node,
+              ids: null
+            },
+        },
+        edges: {
+            e01: {
+                subject: "n0",
+                object: "n1"
+            }
+        }
+    };
+
     describe("test _storeNodes function", () => {
 
         test("test if storeNodes with one hop query", async () => {
@@ -278,6 +297,10 @@ describe("Testing QueryGraphHandler Module", () => {
         const edges = await handler.calculateEdges()
         // if this is undefined (not null) then smartapi-kg treats as if the field doesn't exist (desired behavior)
         expect(edges[0][0].getPredicate()).toBe(undefined)
+      })
+      test("Graph without any ids", async () => {
+        const handler = new QueryGraphHandler(QueryWithNullIds)
+        expect(handler.calculateEdges()).rejects.toThrow(InvalidQueryGraphError)
       })
     })
 });

--- a/src/query_edge.js
+++ b/src/query_edge.js
@@ -38,7 +38,7 @@ module.exports = class QEdge {
   }
 
   getPredicate() {
-    if (this.predicate === undefined) {
+    if (this.predicate === undefined || this.predicate === null) {
       return undefined;
     }
     const predicates = utils.toArray(this.predicate).map((item) => utils.removeBioLinkPrefix(item));

--- a/src/query_execution_edge.js
+++ b/src/query_execution_edge.js
@@ -437,7 +437,7 @@ module.exports = class QueryExecutionEdge {
   }
 
   getPredicate() {
-    if (this.qEdge.predicate === undefined) {
+    if (this.qEdge.predicate === undefined || this.qEdge.predicate === null) {
       return undefined;
     }
     const predicates = utils.toArray(this.qEdge.predicate).map((item) => utils.removeBioLinkPrefix(item));

--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -27,7 +27,7 @@ module.exports = class QueryGraphHandler {
         return;
       }
     }
-    throw new InvalidQueryGraphError('No Query Node has an ID');
+    throw new InvalidQueryGraphError('body/message.query_graph.nodes should contain at least one node with at least one non-null id');
   }
 
   _validateEmptyEdges(queryGraph) {

--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -21,6 +21,15 @@ module.exports = class QueryGraphHandler {
     }
   }
 
+  _validateOneNodeID(queryGraph) {
+    for (let nodeID in queryGraph.nodes) {
+      if (queryGraph.nodes[nodeID] && queryGraph.nodes[nodeID]?.ids?.length > 0) {
+        return;
+      }
+    }
+    throw new InvalidQueryGraphError('No Query Node has an ID');
+  }
+
   _validateEmptyEdges(queryGraph) {
     if (Object.keys(queryGraph.edges).length === 0) {
       throw new InvalidQueryGraphError('Your Query Graph has no edges defined.');
@@ -86,6 +95,7 @@ module.exports = class QueryGraphHandler {
   _validate(queryGraph) {
     this._validateEmptyEdges(queryGraph);
     this._validateEmptyNodes(queryGraph);
+    this._validateOneNodeID(queryGraph);
     this._validateNodeEdgeCorrespondence(queryGraph);
     this._validateDuplicateEdges(queryGraph)
     this._validateCycles(queryGraph);

--- a/src/query_graph.js
+++ b/src/query_graph.js
@@ -210,15 +210,15 @@ module.exports = class QueryGraphHandler {
       for (let qNodeID in this.queryGraph.nodes) {
         //if node has ID but no categories
         if (
-          (!Object.hasOwnProperty.call(this.queryGraph.nodes[qNodeID], 'categories') &&
-          Object.hasOwnProperty.call(this.queryGraph.nodes[qNodeID], 'ids')) ||
-          (Object.hasOwnProperty.call(this.queryGraph.nodes[qNodeID], 'categories') &&
+          (!this.queryGraph.nodes[qNodeID].categories &&
+          this.queryGraph.nodes[qNodeID].ids) ||
+          (this.queryGraph.nodes[qNodeID].categories &&
           // this.queryGraph.nodes[qNodeID].categories.length == 0 &&
-          Object.hasOwnProperty.call(this.queryGraph.nodes[qNodeID], 'ids'))
+          this.queryGraph.nodes[qNodeID].ids)
           ) {
           let userAssignedCategories = this.queryGraph.nodes[qNodeID].categories;
           let categories = await this._findNodeCategories(this.queryGraph.nodes[qNodeID].ids)
-          if (typeof userAssignedCategories !== 'undefined') {
+          if (userAssignedCategories) {
             userAssignedCategories = [...userAssignedCategories]; // new Array for accurate logging after node updated
             categories = categories.filter((category) => !userAssignedCategories.includes(category));
           }
@@ -238,7 +238,7 @@ module.exports = class QueryGraphHandler {
                   `with id${this.queryGraph.nodes[qNodeID].ids.length > 1 ? 's' : ''} `,
                   `[${this.queryGraph.nodes[qNodeID].ids.join(', ')}] `,
                   `${
-                    typeof userAssignedCategories !== 'undefined' && userAssignedCategories.length
+                    userAssignedCategories && userAssignedCategories.length
                     ? `and categor${userAssignedCategories.length === 1 ? 'y' : 'ies'} [${userAssignedCategories.join(', ')}] augmented with`
                     : `assigned`
                   } `,

--- a/src/query_node.js
+++ b/src/query_node.js
@@ -208,7 +208,7 @@ module.exports = class QNode {
     }
 
     hasInput() {
-        return !(typeof this.curie === 'undefined');
+        return !(this.curie === undefined || this.curie === null);
     }
 
     hasEquivalentIDs() {


### PR DESCRIPTION
Fix [issue](https://github.com/biothings/BioThings_Explorer_TRAPI/issues/498)

tested on sample queries referenced in the issue. I could probably also add some tests to ensure this null behavior if necessary?