### PR TITLE
Record cutoff

### DIFF
--- a/src/batch_edge_query.js
+++ b/src/batch_edge_query.js
@@ -138,6 +138,7 @@ module.exports = class BatchEdgeQueryHandler {
       const expanded_APIEdges = this._expandAPIEdges(APIEdges);
       debug('Start to query APIEdges....');
       queryRecords = await this._queryAPIEdges(expanded_APIEdges, unavailableAPIs);
+      if (queryRecords === undefined) return;
       debug('APIEdges are successfully queried....');
       debug(`Filtering out any "undefined" items in (${queryRecords.length}) records`);
       queryRecords = queryRecords.filter((record) => record !== undefined);

--- a/src/index.js
+++ b/src/index.js
@@ -432,6 +432,7 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
       //execute current edge query
       let queryRecords = await handler.query(handler.qEdges, unavailableAPIs);
       this.logs = [...this.logs, ...handler.logs];
+      if (queryRecords === undefined) return;
       // create an edge execution summary
       let success = 0,
         fail = 0,

--- a/src/inferred_mode/inferred_mode.js
+++ b/src/inferred_mode/inferred_mode.js
@@ -152,37 +152,37 @@ module.exports = class InferredQueryHandler {
   async createQueries(qEdge, qSubject, qObject) {
     const templates = await this.findTemplates(qEdge, qSubject, qObject);
     // combine creative query with templates
-    const subQueries = templates.map((template) => {
-      template.nodes.creativeQuerySubject.categories = [
-        ...new Set([...template.nodes.creativeQuerySubject.categories, ...qSubject.categories]),
+    const subQueries = templates.map(({template, queryGraph}) => {
+      queryGraph.nodes.creativeQuerySubject.categories = [
+        ...new Set([...queryGraph.nodes.creativeQuerySubject.categories, ...qSubject.categories]),
       ];
       const creativeQuerySubjectIDs = qSubject.ids ? qSubject.ids : [];
-      template.nodes.creativeQuerySubject.ids = template.nodes.creativeQuerySubject.ids
-        ? [...new Set([...template.nodes.creativeQuerySubject.ids, ...creativeQuerySubjectIDs])]
+      queryGraph.nodes.creativeQuerySubject.ids = queryGraph.nodes.creativeQuerySubject.ids
+        ? [...new Set([...queryGraph.nodes.creativeQuerySubject.ids, ...creativeQuerySubjectIDs])]
         : creativeQuerySubjectIDs;
 
-      template.nodes.creativeQueryObject.categories = [
-        ...new Set([...template.nodes.creativeQueryObject.categories, ...qObject.categories]),
+      queryGraph.nodes.creativeQueryObject.categories = [
+        ...new Set([...queryGraph.nodes.creativeQueryObject.categories, ...qObject.categories]),
       ];
       const qEdgeObjectIDs = qObject.ids ? qObject.ids : [];
-      template.nodes.creativeQueryObject.ids = template.nodes.creativeQueryObject.ids
-        ? [...new Set([...template.nodes.creativeQueryObject.ids, ...qEdgeObjectIDs])]
+      queryGraph.nodes.creativeQueryObject.ids = queryGraph.nodes.creativeQueryObject.ids
+        ? [...new Set([...queryGraph.nodes.creativeQueryObject.ids, ...qEdgeObjectIDs])]
         : qEdgeObjectIDs;
 
-      if (!template.nodes.creativeQuerySubject.categories.length) {
-        delete template.nodes.creativeQuerySubject.categories;
+      if (!queryGraph.nodes.creativeQuerySubject.categories.length) {
+        delete queryGraph.nodes.creativeQuerySubject.categories;
       }
-      if (!template.nodes.creativeQueryObject.categories.length) {
-        delete template.nodes.creativeQueryObject.categories;
+      if (!queryGraph.nodes.creativeQueryObject.categories.length) {
+        delete queryGraph.nodes.creativeQueryObject.categories;
       }
-      if (!template.nodes.creativeQuerySubject.ids.length) {
-        delete template.nodes.creativeQuerySubject.ids;
+      if (!queryGraph.nodes.creativeQuerySubject.ids.length) {
+        delete queryGraph.nodes.creativeQuerySubject.ids;
       }
-      if (!template.nodes.creativeQueryObject.ids.length) {
-        delete template.nodes.creativeQueryObject.ids;
+      if (!queryGraph.nodes.creativeQueryObject.ids.length) {
+        delete queryGraph.nodes.creativeQueryObject.ids;
       }
 
-      return template;
+      return {template, queryGraph};
     });
 
     return subQueries;
@@ -364,9 +364,13 @@ module.exports = class InferredQueryHandler {
     let stop = false;
     let mergedResultsCount = {};
 
-    await async.eachOfSeries(subQueries, async (queryGraph, i) => {
+    await async.eachOfSeries(subQueries, async ({template, queryGraph}, i) => {
       if (stop) {
         return;
+      }
+      if (global.queryInformation?.queryGraph) {
+        global.queryInformation.isCreativeMode = true;
+        global.queryInformation.creativeTemplate = template;
       }
       const handler = new this.TRAPIQueryHandler(this.options, this.path, this.predicatePath, this.includeReasoner);
       try {

--- a/src/inferred_mode/template_lookup.js
+++ b/src/inferred_mode/template_lookup.js
@@ -44,7 +44,10 @@ exports.getTemplates = async (lookups) => {
     }, []),
   ];
   return await async.map(matchingTemplatePaths, async (templatePath) => {
-    return JSON.parse(await fs.readFile(templatePath)).message.query_graph;
+    return {
+      template: templatePath.substring(templatePath.lastIndexOf('/') + 1),
+      queryGraph: JSON.parse(await fs.readFile(templatePath)).message.query_graph,
+    };
   });
 };
 


### PR DESCRIPTION
Store information for useful logging when stopping due to record cutoff threshold. Additionally, handle cases where query execution is stopped due to secondary threshold.

Related: 
biothings/BioThings_Explorer_TRAPI#547
biothings/call-apis.js#67
