### PR TITLE
Only add is_set if ids are expanded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,10 +100,13 @@ exports.TRAPIQueryHandler = class TRAPIQueryHandler {
         debug(log_msg);
         this.logs.push(new LogEntry('INFO', null, log_msg).getLog());
 
+        const foundExpandedIds = expanded.length > queryGraph.nodes[nodeId].ids.length;
         queryGraph.nodes[nodeId].ids = expanded;
 
+        const nodeMissingIsSet = !queryGraph.nodes[nodeId].hasOwnProperty('is_set') || !queryGraph.nodes[nodeId].is_set;
+
         //make sure is_set is true
-        if (!queryGraph.nodes[nodeId].hasOwnProperty('is_set') || !queryGraph.nodes[nodeId].is_set) {
+        if (foundExpandedIds && nodeMissingIsSet) {
           queryGraph.nodes[nodeId].is_set = true;
           log_msg = `Added is_set:true to node ${nodeId}`;
           debug(log_msg);


### PR DESCRIPTION
Addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/555.

Test cases:

<details>
<summary>Issue query</summary> 

Using http://localhost:3000/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query

```
{
  "message": {
    "query_graph": {
      "nodes": {
        "n0": {
          "ids": ["UniProtKB:P35968", "UniProtKB:Q07912"],
          "categories": ["biolink:Gene"]
        },
        "n1": {
          "categories": ["biolink:SmallMolecule"]
        }
      },
      "edges": {
        "e1": {
          "subject": "n0",
          "object": "n1"
        }
      }
    }
  }
}

```

</details>

<details>
<summary>query that should expand</summary>

```
{
  "message": {
    "query_graph": {
      "nodes": {
        "n0": {
          "categories": ["biolink:ChemicalEntity"]
        },
        "n1": {
          "ids": ["MONDO:0018997"],
          "categories": ["biolink:DiseaseOrPhenotypicFeature"],
          "name": "noonan syndrome"
        }
      },
      "edges": {
        "eA": {
          "subject": "n0",
          "object": "n1",
          "predicates": ["biolink:treats"]
        }
      }
    }
  }
}

```

</details>

CC @colleenXu for quick testing before deployment to dev.