### PR TITLE
TRAPI 1.4: Support Bull logging

### DIFF
--- a/src/log_entry.js
+++ b/src/log_entry.js
@@ -9,13 +9,21 @@ module.exports = class LogEntry {
   }
 
   getLog() {
-    return {
+    const log = {
       timestamp: new Date().toISOString(),
       level: this.level,
       message: this.message,
       code: this.code,
+    }
+    if (global.job) {
+      global.job.log(JSON.stringify(log, undefined, 2));
+    }
+    return {
+      ...log,
       data: this.data,
-      toJSON() { return _.omit(this, ['data', 'toJSON']) }
+      toJSON() {
+        return _.omit(this, ["data", "toJSON"]);
+      },
     };
   }
 };


### PR DESCRIPTION
*Required by biothings/BioThings_Explorer_TRAPI#612*

Supports realtime TRAPI logs to Bull job, if provided.

Commit shows double-revert because I accidentally pushed to main instead of new branch at first >.<