### PR TITLE
Use SmartAPI ID to get primary source from API_LIST

### DIFF
--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -57,6 +57,7 @@ module.exports = class BTEGraph {
           });
         }
         this.edges[recordHash].addAPI(record.api);
+        this.edges[recordHash].addApiID(record.association.smartapi.id)
         this.edges[recordHash].addInforesCurie(record.apiInforesCurie);
         this.edges[recordHash].addSource(record.metaEdgeSource);
         this.edges[recordHash].addPublication(record.publications);
@@ -98,8 +99,8 @@ module.exports = class BTEGraph {
   checkPrimaryKnowledgeSources(knowledgeGraph) {
     let logs = []
     Object.keys(knowledgeGraph.edges).map((edge) => {
-      const has_primary_knowledge_source = knowledgeGraph.edges[edge].attributes.some(e => 
-        e.attribute_type_id === 'biolink:primary_knowledge_source' && 
+      const has_primary_knowledge_source = knowledgeGraph.edges[edge].attributes.some(e =>
+        e.attribute_type_id === 'biolink:primary_knowledge_source' &&
         ( e.value?.length || (!Array.isArray(e.value) && e.value))
       );
       if (!has_primary_knowledge_source) {

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -57,7 +57,7 @@ module.exports = class BTEGraph {
           });
         }
         this.edges[recordHash].addAPI(record.api);
-        this.edges[recordHash].addApiID(record.association.smartapi.id)
+        this.edges[recordHash].addApiID(record.association?.smartapi?.id)
         this.edges[recordHash].addInforesCurie(record.apiInforesCurie);
         this.edges[recordHash].addSource(record.metaEdgeSource);
         this.edges[recordHash].addPublication(record.publications);

--- a/src/graph/kg_edge.js
+++ b/src/graph/kg_edge.js
@@ -5,6 +5,7 @@ module.exports = class KGEdge {
     this.subject = info.subject;
     this.object = info.object;
     this.apis = new Set();
+    this.api_ids = new Set();
     this.inforesCuries = new Set();
     this.sources = new Set();
     this.publications = new Set();
@@ -22,6 +23,18 @@ module.exports = class KGEdge {
     api.map((item) => {
       this.apis.add(item);
     });
+  }
+
+  addApiID(id) {
+    if (typeof id === 'undefined') {
+      return
+    }
+    if (!Array.isArray(id)) {
+      id = [id]
+    }
+    id.map((item) => {
+      this.api_ids.add(item);
+    })
   }
 
   addInforesCurie(inforesCurie) {

--- a/src/graph/knowledge_graph.js
+++ b/src/graph/knowledge_graph.js
@@ -85,14 +85,14 @@ module.exports = class KnowledgeGraph {
       },
     ];
 
-    const direct_info_providers = this.apiList?.filter(e => e.primarySource)?.map(e => e.name) ?? []
+    const direct_info_providers = this.apiList?.filter(e => e.primarySource)?.map(e => e.id) ?? []
 
     if (kgEdge.attributes['edge-attributes']) {
       //handle TRAPI APIs (Situation A of https://github.com/biothings/BioThings_Explorer_TRAPI/issues/208) and APIs that define 'edge-atributes' in x-bte
       attributes = [...attributes, ...kgEdge.attributes['edge-attributes']];
     } else if (
       //handle direct info providers (Situation C of https://github.com/biothings/BioThings_Explorer_TRAPI/issues/208)
-      direct_info_providers.some((api_name) => kgEdge.apis.has(api_name))
+      direct_info_providers.some((api_id) => kgEdge.apis.has(api_id))
     ) {
       attributes = [...attributes];
       //primary knowledge source


### PR DESCRIPTION
Currently, API name is used to match kgEdge to API_LIST when checking if an API is a primary knowledge source. This is fine, but SmartAPI ID is more reliable as we occasionally have name mismatches.

Comparing infores might be better (as infores is expected to change even more infrequently than SmartAPI ID) but would require more work:
- ensuring that infores is propagated up properly
- adding infores to every item of the API_LIST