### PR TITLE
Case insensitive prefix in smartapi/query

### DIFF
--- a/src/edge_manager.js
+++ b/src/edge_manager.js
@@ -176,8 +176,8 @@ module.exports = class QueryEdgeManager {
   _filterEdgeRecords(qEdge) {
     let keep = [];
     let records = qEdge.records;
-    let subjectCuries = qEdge.subject.curie;
-    let objectCuries = qEdge.object.curie;
+    let subjectCuries = Array.isArray(qEdge.subject.curie) ? qEdge.subject.curie.map(s => s.toLowerCase()) : qEdge.subject.curie.toLowerCase();
+    let objectCuries =  Array.isArray(qEdge.object.curie) ? qEdge.object.curie.map(s => s.toLowerCase()) : qEdge.object.curie.toLowerCase();
     debug(
       `'${qEdge.getID()}' Reversed[${qEdge.reverse}] (${JSON.stringify(subjectCuries.length || 0)})` +
         `--(${JSON.stringify(objectCuries.length || 0)}) entities / (${records.length}) records.`,
@@ -197,17 +197,17 @@ module.exports = class QueryEdgeManager {
       //compare record I/O ids against edge node ids
       // #1 check equivalent ids
       record.subject.equivalentCuries.forEach((curie) => {
-        subjectIDs.add(curie);
+        subjectIDs.add(curie?.toLowerCase());
       });
       record.object.equivalentCuries.forEach((curie) => {
-        objectIDs.add(curie);
+        objectIDs.add(curie?.toLowerCase());
       });
       // #2 ensure we have the primaryID
-      subjectIDs.add(record.subject.curie);
-      objectIDs.add(record.object.curie);
+      subjectIDs.add(record.subject.curie?.toLowerCase());
+      objectIDs.add(record.object.curie?.toLowerCase());
       // #3 make sure we at least have the original
-      subjectIDs.add(record.subject.original);
-      objectIDs.add(record.object.original);
+      subjectIDs.add(record.subject.original?.toLowerCase());
+      objectIDs.add(record.object.original?.toLowerCase());
       // check ids
       subjectMatch = _.intersection([...subjectIDs], execSubjectCuries).length;
       objectMatch = _.intersection([...objectIDs], execObjectCuries).length;

--- a/src/qedge2apiedge.js
+++ b/src/qedge2apiedge.js
@@ -84,6 +84,9 @@ module.exports = class QEdge2APIEdgeHandler {
       if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
           if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            // make sure the case of prefix matches the inputPrefix
+            equivalentCurie = equivalentCurie.replace(new RegExp(inputPrefix, "i"), inputPrefix);
+
             const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
               ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
               : equivalentCurie.split(':').slice(1).join(':');
@@ -130,6 +133,9 @@ module.exports = class QEdge2APIEdgeHandler {
       } else if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
           if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            // make sure the case of prefix matches the inputPrefix
+            equivalentCurie = equivalentCurie.replace(new RegExp(inputPrefix, "i"), inputPrefix);
+
               const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
                   ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
                   : equivalentCurie.split(':').slice(1).join(':');
@@ -185,6 +191,9 @@ module.exports = class QEdge2APIEdgeHandler {
       if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
           if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            // make sure the case of prefix matches the inputPrefix
+            equivalentCurie = equivalentCurie.replace(new RegExp(inputPrefix, "i"), inputPrefix);
+
             const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
               ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
               : equivalentCurie.split(':').slice(1).join(':');
@@ -231,6 +240,9 @@ module.exports = class QEdge2APIEdgeHandler {
       } else if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
           if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            // make sure the case of prefix matches the inputPrefix
+            equivalentCurie = equivalentCurie.replace(new RegExp(inputPrefix, "i"), inputPrefix);
+
             const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
               ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
               : equivalentCurie.split(':').slice(1).join(':');

--- a/src/qedge2apiedge.js
+++ b/src/qedge2apiedge.js
@@ -83,9 +83,9 @@ module.exports = class QEdge2APIEdgeHandler {
     Object.entries(resolvedCuries).forEach(([curie, entity]) => {
       if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
-          if (equivalentCurie.includes(inputPrefix)) {
-            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0])
-              ? equivalentCurie
+          if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
+              ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
               : equivalentCurie.split(':').slice(1).join(':');
             const APIEdge = { ...metaXEdge };
             APIEdge.input = id;
@@ -129,10 +129,10 @@ module.exports = class QEdge2APIEdgeHandler {
         }
       } else if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
-          if (equivalentCurie.includes(inputPrefix)) {
-            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0])
-              ? equivalentCurie
-              : equivalentCurie.split(':').slice(1).join(':');
+          if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+              const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
+                  ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
+                  : equivalentCurie.split(':').slice(1).join(':');
             id_mapping[equivalentCurie] = curie;
             input_resolved_identifiers[curie] = entity;
             inputs.push(id);
@@ -184,9 +184,9 @@ module.exports = class QEdge2APIEdgeHandler {
     Object.entries(resolvedCuries).forEach(([curie, entity]) => {
       if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
-          if (equivalentCurie.includes(inputPrefix)) {
-            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0])
-              ? equivalentCurie
+          if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
+              ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
               : equivalentCurie.split(':').slice(1).join(':');
             const APIEdge = { ...metaXEdge };
             APIEdge.input = { queryInputs: id, ...APIEdge.query_operation.templateInputs };
@@ -230,9 +230,9 @@ module.exports = class QEdge2APIEdgeHandler {
         }
       } else if (entity.primaryTypes.includes(inputType.replace('biolink:', ''))) {
         entity.equivalentIDs.forEach((equivalentCurie) => {
-          if (equivalentCurie.includes(inputPrefix)) {
-            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0])
-              ? equivalentCurie
+          if (equivalentCurie.toUpperCase().includes(inputPrefix.toUpperCase())) {
+            const id = CURIE_WITH_PREFIXES.includes(equivalentCurie.split(':')[0].toUpperCase())
+              ? [equivalentCurie.split(':')[0].toUpperCase(), ...equivalentCurie.split(':').slice(1)].join(':')
               : equivalentCurie.split(':').slice(1).join(':');
             id_mapping[equivalentCurie] = curie;
             input_resolved_identifiers[curie] = entity;

--- a/src/query_node.js
+++ b/src/query_node.js
@@ -146,7 +146,7 @@ module.exports = class QNode {
     // If a new entity has any alias intersection with an existing entity, keep it
     Object.entries(newCuries).forEach(([newMainID, currentAliases]) => {
       const someIntersection = Object.entries(this.expanded_curie).some(([existingMainID, existingAliases]) => {
-        return currentAliases.some((currentAlias) => existingAliases.includes(currentAlias));
+        return currentAliases.some((currentAlias) => existingAliases.some(existingAlias => currentAlias.toLowerCase() === existingAlias.toLowerCase()));
       });
       if (someIntersection) {
         if (!keep[newMainID]) keep[newMainID] = currentAliases;


### PR DESCRIPTION
https://github.com/biothings/biothings_explorer/issues/640

1. ignores case when comparing smartapi prefix to id prefixes from SRI (this means that query will be generated regardless if case given by SRI node normalizer is different than that in the smartapi annotation)
2. case of prefix in the query graph will be ignored when filtering out records