### PR TITLE
Fix QueryResults and inferred_mode tests

### DIFF
--- a/__test__/integration/QueryResult.test.js
+++ b/__test__/integration/QueryResult.test.js
@@ -46,7 +46,7 @@ describe('Testing QueryResults Module', () => {
       );
 
       test('should get n1, n2 and e01', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e01: {
             connected_to: [],
@@ -127,7 +127,7 @@ describe('Testing QueryResults Module', () => {
         );
 
         test('should get n1, n2, n3 and e01, e02', async () => {
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
           await queryResult.update({
             e01: {
@@ -222,7 +222,7 @@ describe('Testing QueryResults Module', () => {
         );
 
         test('should get n1, n2, n3 and e01, e02', async () => {
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             e01: {
               connected_to: ['e02'],
@@ -316,7 +316,7 @@ describe('Testing QueryResults Module', () => {
         );
 
         test('should get n1, n2, n3 and e01, e02', async () => {
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             e01: {
               connected_to: ['e02'],
@@ -412,7 +412,7 @@ describe('Testing QueryResults Module', () => {
         );
 
         test('should get n1, n2, n3 and e01, e02', async () => {
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             e01: {
               connected_to: ['e02'],
@@ -508,7 +508,7 @@ describe('Testing QueryResults Module', () => {
         );
 
         test('should get n1, n2, n3 and e01, e02', async () => {
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             e01: {
               connected_to: ['e02'],
@@ -631,7 +631,7 @@ describe('Testing QueryResults Module', () => {
       );
 
       test('should get 2 results when query graph is -- and records are -<', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
         await queryResult.update({
           e01: {
@@ -977,14 +977,14 @@ describe('Testing QueryResults Module', () => {
 
     describe('repeat calls', () => {
       test('should get 0 results for update (0) & getResults (1)', async () => {
-        const queryResultInner = new QueryResult();
+        const queryResultInner = new QueryResult(provenanceUsesServiceProvider = false);
         const resultsInner = queryResultInner.getResults();
         expect(JSON.stringify(resultsInner)).toEqual(JSON.stringify([]));
       });
 
       // inputs all the same below here
 
-      const queryResultOuter = new QueryResult();
+      const queryResultOuter = new QueryResult(provenanceUsesServiceProvider = false);
       let resultsOuter;
       test('just wrapping for async', async () => {
         await queryResultOuter.update({
@@ -1001,7 +1001,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get same results: update (1) & getResults (1) vs. update (2) & getResults (1)', async () => {
-        const queryResultInner = new QueryResult();
+        const queryResultInner = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResultInner.update({
           e0: {
             connected_to: ['e1'],
@@ -1027,7 +1027,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get same results: update (1) & getResults (1) vs. update (2) & getResults (2)', async () => {
-        const queryResultInner = new QueryResult();
+        const queryResultInner = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResultInner.update({
           e0: {
             connected_to: ['e1'],
@@ -1054,7 +1054,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get same results: update (1) & getResults (1) vs. update (1) & getResults (2)', async () => {
-        const queryResultInner = new QueryResult();
+        const queryResultInner = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResultInner.update({
           e0: {
             connected_to: ['e1'],
@@ -1073,7 +1073,7 @@ describe('Testing QueryResults Module', () => {
 
     describe('query graph: →', () => {
       test('should get 1 result with record: →', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: [],
@@ -1090,7 +1090,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 4 results for 4 different records per edge: 𝍬', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: [],
@@ -1125,7 +1125,7 @@ describe('Testing QueryResults Module', () => {
 
       // TODO: Do we want to test for removing duplicates?
       test('should get 1 result for the same record repeated 4 times: 𝍬', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: [],
@@ -1148,7 +1148,7 @@ describe('Testing QueryResults Module', () => {
 
       //      // TODO: this test fails. Do we need to handle this case?
       //      test('should get 1 result for the same record repeated twice and reversed twice: 𝍬', async () => {
-      //        const queryResult = new QueryResult();
+      //        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
       //        await queryResult.update({
       //          "e1": {
       //            "connected_to": [],
@@ -1170,7 +1170,7 @@ describe('Testing QueryResults Module', () => {
       //
       //      // TODO: this one fails. Do we need to worry about this case?
       //      test('should get 2 results for the same record repeated twice and reversed twice: ⇉⇇', async () => {
-      //        const queryResult = new QueryResult();
+      //        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
       //        await queryResult.update({
       //          "e1": {
       //            "connected_to": ["e1_reversed"],
@@ -1203,7 +1203,7 @@ describe('Testing QueryResults Module', () => {
       //      });
 
       test('should get 1 result with 2 edge mappings when predicates differ: ⇉', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: [],
@@ -1226,7 +1226,7 @@ describe('Testing QueryResults Module', () => {
       // b/c we need it to take into account the API source.
       /*
       test('should get 1 result with 2 edge mappings when API sources differ: ⇉', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           "e0": {
             "connected_to": [],
@@ -1250,7 +1250,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 1 result with 4 edge mappings when predicates & API sources differ: 𝍬', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           "e0": {
             "connected_to": [],
@@ -1282,7 +1282,7 @@ describe('Testing QueryResults Module', () => {
 
     describe('query graph: →→', () => {
       test('should get 1 result with records: →→', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1302,7 +1302,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[0].analyses[0]).toHaveProperty('score');
       });
       test('should get 2 results with records: >-', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1326,7 +1326,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[1].analyses[0]).toHaveProperty('score');
       });
       test('should get 4 results with records: ><', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1358,7 +1358,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[3].analyses[0]).toHaveProperty('score');
       });
       test('should get 2 results with records: >< (is_set for n0)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0_left_is_set: {
             connected_to: ['e1'],
@@ -1382,7 +1382,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[1].analyses[0]).toHaveProperty('score');
       });
       test('should get 4 results with records: >< (is_set for n1)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0_right_is_set: {
             connected_to: ['e1_left_is_set'],
@@ -1410,7 +1410,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 1 result with records: >< (is_set for n0 and n2)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0_left_is_set: {
             connected_to: ['e1_reversed_left_is_set'],
@@ -1431,7 +1431,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 1 result with records: >< (is_set for n0, n1 and n2)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0_both_is_set: {
             connected_to: ['e1_both_is_set'],
@@ -1456,7 +1456,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 2 results with records: ⇉⇉', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1482,7 +1482,7 @@ describe('Testing QueryResults Module', () => {
 
       // TODO: Do we want to test for removing duplicates?
       test('should get 1 result with records: ⇉⇉ (duplicates)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1502,7 +1502,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[0].analyses[0]).toHaveProperty('score');
       });
       test('should get 2 results with records: -<', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1526,7 +1526,7 @@ describe('Testing QueryResults Module', () => {
         expect(results[1].analyses[0]).toHaveProperty('score');
       });
       test('should get 1 result with records: →← (directionality does not match query graph)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1_reversed'],
@@ -1642,7 +1642,7 @@ describe('Testing QueryResults Module', () => {
           });
         });
 
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1732,7 +1732,7 @@ describe('Testing QueryResults Module', () => {
           );
         });
 
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -1833,7 +1833,7 @@ describe('Testing QueryResults Module', () => {
             });
           });
 
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             "e0": {
               "connected_to": ["e1"],
@@ -1996,7 +1996,7 @@ describe('Testing QueryResults Module', () => {
             });
           });
 
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             "e0": {
               "connected_to": ["e1"],
@@ -2103,7 +2103,7 @@ describe('Testing QueryResults Module', () => {
             });
           });
 
-          const queryResult = new QueryResult();
+          const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
           await queryResult.update({
             "e0": {
               "connected_to": ["e1"],
@@ -2140,7 +2140,7 @@ describe('Testing QueryResults Module', () => {
 
     describe('query graph: →←', () => {
       test('should get 1 result with records: →←', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1_reversed'],
@@ -2161,7 +2161,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 1 result with records: →→ (directionality does not match query graph)', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e0: {
             connected_to: ['e1'],
@@ -2184,7 +2184,7 @@ describe('Testing QueryResults Module', () => {
 
     describe('query graph: ←→', () => {
       test('should get 1 result for 1 record per edge: ←→', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         await queryResult.update({
           e1_reversed: {
             connected_to: ['e4'],
@@ -2205,7 +2205,7 @@ describe('Testing QueryResults Module', () => {
       });
 
       test('should get 0 results due to unconnected record: ←̽→', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
         await queryResult.update({
           e1_reversed: {
@@ -2231,7 +2231,7 @@ describe('Testing QueryResults Module', () => {
        *               -e2-> n3
        */
       test('should get 1 result for 1 record per edge: →⇉⮆', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
         await queryResult.update({
           e0: {
@@ -2265,7 +2265,7 @@ describe('Testing QueryResults Module', () => {
       //       *               -e2-> n3
       //       */
       //      test('should get 1 result for 1 record per edge: ←⇉⮆', async () => {
-      //        const queryResult = new QueryResult();
+      //        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
       //
       //        await queryResult.update({
       //          "e0_reversed": {
@@ -2302,7 +2302,7 @@ describe('Testing QueryResults Module', () => {
        *               -e2-> n3
        */
       test('should get 1 result for 1 record per edge: →⇆⮆', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
         await queryResult.update({
           e0: {
@@ -2335,7 +2335,7 @@ describe('Testing QueryResults Module', () => {
        *               <-e2- n3
        */
       test('should get 1 result for 1 record per edge: →⇇⮆', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
         await queryResult.update({
           e0: {
@@ -2368,7 +2368,7 @@ describe('Testing QueryResults Module', () => {
        *               ---> n2
        */
       test('should get 0 results due to unconnected record: -<̽', async () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
 
         await queryResult.update({
           e0: {
@@ -2401,7 +2401,7 @@ describe('Testing QueryResults Module', () => {
     //       */
     //
     ////      test('should get 1 result for 1 record per edge', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2448,7 +2448,7 @@ describe('Testing QueryResults Module', () => {
     ////      });
     //
     ////      test('should get 2 results for 2 records per edge at n0', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2503,7 +2503,7 @@ describe('Testing QueryResults Module', () => {
     ////      });
     ////
     ////      test('should get 2 results for 2 records per edge at n1', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2573,7 +2573,7 @@ describe('Testing QueryResults Module', () => {
     ////       *                 -e3-> n4a -e6->
     ////       */
     ////      test('should get 3 results for n0a→n1a, n0a→n1b, n0b→n1a', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2656,7 +2656,7 @@ describe('Testing QueryResults Module', () => {
     ////       *                 -e3-> n4a -e6->
     ////       */
     ////      test('should get 4 results for n0a→n1a, n0a→n1b, n0b→n1a, n0b→n1b', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2727,7 +2727,7 @@ describe('Testing QueryResults Module', () => {
     ////      });
     //
     //      test('should get 0 results due to unconnected record at n1 (n1a vs. n1b)', async () => {
-    //        const queryResult = new QueryResult();
+    //        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     //
     //        await queryResult.update({
     //          "e0": {
@@ -2766,7 +2766,7 @@ describe('Testing QueryResults Module', () => {
     //      });
     //
     ////      test('should get 1 result & ignore unconnected record', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2813,7 +2813,7 @@ describe('Testing QueryResults Module', () => {
     ////      });
     ////
     ////      test('should get 1 result & ignore 4 unconnected records', async () => {
-    ////        const queryResult = new QueryResult();
+    ////        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
     ////
     ////        await queryResult.update({
     ////          "e0": {
@@ -2928,7 +2928,7 @@ describe('Testing QueryResults Module', () => {
           gene_symbol: 'HRAS',
         },
       });
-      const queryResult = new QueryResult();
+      const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
       await queryResult.update({
         e01: {
           connected_to: [],
@@ -2984,13 +2984,13 @@ describe('Testing QueryResults Module', () => {
       };
 
       test('Should select leaf node', () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         const [[initialNode, initialEdge]] = queryResult._getValidInitialPairs(exampleRecordsByQEdgeID);
         expect(initialNode).toEqual('n3');
         expect(initialEdge).toEqual('e1');
       });
       test('Should select leaf node with fewest records on associated edge', () => {
-        const queryResult = new QueryResult();
+        const queryResult = new QueryResult(provenanceUsesServiceProvider = false);
         const example = cloneDeep(exampleRecordsByQEdgeID);
         example.e1.records.push({ fake: true });
         const [[initialNode, initialEdge]] = queryResult._getValidInitialPairs(example);

--- a/__test__/integration/QueryResult.test.js
+++ b/__test__/integration/QueryResult.test.js
@@ -42,7 +42,7 @@ describe('Testing QueryResults Module', () => {
           source: 'DGIdb',
           api_name: 'BioThings DGIDB API',
         },
-        edge1,
+        edge1
       );
 
       test('should get n1, n2 and e01', async () => {
@@ -56,8 +56,8 @@ describe('Testing QueryResults Module', () => {
         expect(queryResult.getResults().length).toEqual(1);
         expect(queryResult.getResults()[0].node_bindings).toHaveProperty('n1');
         expect(queryResult.getResults()[0].node_bindings).toHaveProperty('n2');
-        expect(queryResult.getResults()[0].edge_bindings).toHaveProperty('e01');
-        expect(queryResult.getResults()[0]).toHaveProperty('score');
+        expect(queryResult.getResults()[0].analyses[0].edge_bindings).toHaveProperty('e01');
+        expect(queryResult.getResults()[0].analyses[0]).toHaveProperty('score');
       });
     });
 
@@ -149,11 +149,11 @@ describe('Testing QueryResults Module', () => {
           expect(results[0].node_bindings).toHaveProperty('n2');
           expect(results[0].node_bindings).toHaveProperty('n3');
 
-          expect(Object.keys(results[0].edge_bindings).length).toEqual(2);
-          expect(results[0].edge_bindings).toHaveProperty('e01');
-          expect(results[0].edge_bindings).toHaveProperty('e02');
+          expect(Object.keys(results[0].analyses[0].edge_bindings).length).toEqual(2);
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e01');
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e02');
 
-          expect(results[0]).toHaveProperty('score');
+          expect(results[0].analyses[0]).toHaveProperty('score');
         });
       });
 
@@ -243,11 +243,11 @@ describe('Testing QueryResults Module', () => {
           expect(results[0].node_bindings).toHaveProperty('n2');
           expect(results[0].node_bindings).toHaveProperty('n3');
 
-          expect(Object.keys(results[0].edge_bindings).length).toEqual(2);
-          expect(results[0].edge_bindings).toHaveProperty('e01');
-          expect(results[0].edge_bindings).toHaveProperty('e02');
+          expect(Object.keys(results[0].analyses[0].edge_bindings).length).toEqual(2);
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e01');
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e02');
 
-          expect(results[0]).toHaveProperty('score');
+          expect(results[0].analyses[0]).toHaveProperty('score');
         });
       });
 
@@ -337,11 +337,11 @@ describe('Testing QueryResults Module', () => {
           expect(results[0].node_bindings).toHaveProperty('n2');
           expect(results[0].node_bindings).toHaveProperty('n3');
 
-          expect(Object.keys(results[0].edge_bindings).length).toEqual(2);
-          expect(results[0].edge_bindings).toHaveProperty('e01');
-          expect(results[0].edge_bindings).toHaveProperty('e02');
+          expect(Object.keys(results[0].analyses[0].edge_bindings).length).toEqual(2);
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e01');
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e02');
 
-          expect(results[0]).toHaveProperty('score');
+          expect(results[0].analyses[0]).toHaveProperty('score');
         });
       });
 
@@ -433,11 +433,11 @@ describe('Testing QueryResults Module', () => {
           expect(results[0].node_bindings).toHaveProperty('n2');
           expect(results[0].node_bindings).toHaveProperty('n3');
 
-          expect(Object.keys(results[0].edge_bindings).length).toEqual(2);
-          expect(results[0].edge_bindings).toHaveProperty('e01');
-          expect(results[0].edge_bindings).toHaveProperty('e02');
+          expect(Object.keys(results[0].analyses[0].edge_bindings).length).toEqual(2);
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e01');
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e02');
 
-          expect(results[0]).toHaveProperty('score');
+          expect(results[0].analyses[0]).toHaveProperty('score');
         });
       });
 
@@ -529,11 +529,11 @@ describe('Testing QueryResults Module', () => {
           expect(results[0].node_bindings).toHaveProperty('n2');
           expect(results[0].node_bindings).toHaveProperty('n3');
 
-          expect(Object.keys(results[0].edge_bindings).length).toEqual(2);
-          expect(results[0].edge_bindings).toHaveProperty('e01');
-          expect(results[0].edge_bindings).toHaveProperty('e02');
+          expect(Object.keys(results[0].analyses[0].edge_bindings).length).toEqual(2);
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e01');
+          expect(results[0].analyses[0].edge_bindings).toHaveProperty('e02');
 
-          expect(results[0]).toHaveProperty('score');
+          expect(results[0].analyses[0]).toHaveProperty('score');
         });
       });
     });
@@ -653,22 +653,22 @@ describe('Testing QueryResults Module', () => {
         expect(results[0].node_bindings).toHaveProperty('n2');
         expect(results[0].node_bindings).toHaveProperty('n3');
 
-        expect(Object.keys(results[0].edge_bindings).length).toEqual(2);
-        expect(results[0].edge_bindings).toHaveProperty('e01');
-        expect(results[0].edge_bindings).toHaveProperty('e02');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).length).toEqual(2);
+        expect(results[0].analyses[0].edge_bindings).toHaveProperty('e01');
+        expect(results[0].analyses[0].edge_bindings).toHaveProperty('e02');
 
-        expect(results[0]).toHaveProperty('score');
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).length).toEqual(3);
         expect(results[1].node_bindings).toHaveProperty('n1');
         expect(results[1].node_bindings).toHaveProperty('n2');
         expect(results[1].node_bindings).toHaveProperty('n3');
 
-        expect(Object.keys(results[1].edge_bindings).length).toEqual(2);
-        expect(results[1].edge_bindings).toHaveProperty('e01');
-        expect(results[1].edge_bindings).toHaveProperty('e02');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).length).toEqual(2);
+        expect(results[1].analyses[0].edge_bindings).toHaveProperty('e01');
+        expect(results[1].analyses[0].edge_bindings).toHaveProperty('e02');
 
-        expect(results[1]).toHaveProperty('score');
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
     });
   });
@@ -1085,8 +1085,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 4 results for 4 different records per edge: 𝍬', async () => {
@@ -1107,20 +1107,20 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(4);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[2].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[2].edge_bindings).sort()).toEqual(['e0']);
-        expect(results[2]).toHaveProperty('score');
+        expect(Object.keys(results[2].analyses[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(results[2].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[3].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[3].edge_bindings).sort()).toEqual(['e0']);
-        expect(results[3]).toHaveProperty('score');
+        expect(Object.keys(results[3].analyses[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(results[3].analyses[0]).toHaveProperty('score');
       });
 
       // TODO: Do we want to test for removing duplicates?
@@ -1142,8 +1142,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       //      // TODO: this test fails. Do we need to handle this case?
@@ -1215,11 +1215,11 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0']);
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0']);
 
-        expect(results[0].edge_bindings['e0'].length).toEqual(2);
+        expect(results[0].analyses[0].edge_bindings['e0'].length).toEqual(2);
 
-        expect(results[0]).toHaveProperty('score');
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       // These two tests won't work until the KG edge ID assignment system is updated,
@@ -1298,8 +1298,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
       test('should get 2 results with records: >-', async () => {
         const queryResult = new QueryResult();
@@ -1318,12 +1318,12 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(2);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
       test('should get 4 results with records: ><', async () => {
         const queryResult = new QueryResult();
@@ -1342,20 +1342,20 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(4);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[2].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[2].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[2]).toHaveProperty('score');
+        expect(Object.keys(results[2].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[2].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[3].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[3].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[3]).toHaveProperty('score');
+        expect(Object.keys(results[3].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[3].analyses[0]).toHaveProperty('score');
       });
       test('should get 2 results with records: >< (is_set for n0)', async () => {
         const queryResult = new QueryResult();
@@ -1374,12 +1374,12 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(2);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0_with_is_set', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0_left_is_set', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0_left_is_set', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0_with_is_set', 'n1', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0_left_is_set', 'e1']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0_left_is_set', 'e1']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
       test('should get 4 results with records: >< (is_set for n1)', async () => {
         const queryResult = new QueryResult();
@@ -1401,12 +1401,12 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(4);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1_with_is_set', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0_right_is_set', 'e1_left_is_set']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0_right_is_set', 'e1_left_is_set']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1_with_is_set', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0_right_is_set', 'e1_left_is_set']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0_right_is_set', 'e1_left_is_set']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 1 result with records: >< (is_set for n0 and n2)', async () => {
@@ -1426,8 +1426,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0_with_is_set', 'n1', 'n2_with_is_set']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0_left_is_set', 'e1_reversed_left_is_set']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0_left_is_set', 'e1_reversed_left_is_set']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 1 result with records: >< (is_set for n0, n1 and n2)', async () => {
@@ -1451,8 +1451,8 @@ describe('Testing QueryResults Module', () => {
           'n1_with_is_set',
           'n2_with_is_set',
         ]);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0_both_is_set', 'e1_both_is_set']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0_both_is_set', 'e1_both_is_set']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 2 results with records: ⇉⇉', async () => {
@@ -1472,12 +1472,12 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(2);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
 
       // TODO: Do we want to test for removing duplicates?
@@ -1498,8 +1498,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
       test('should get 2 results with records: -<', async () => {
         const queryResult = new QueryResult();
@@ -1518,12 +1518,12 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(2);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
       test('should get 1 result with records: →← (directionality does not match query graph)', async () => {
         const queryResult = new QueryResult();
@@ -1542,8 +1542,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 5k results when e0 has 100 records (50 connected, 50 not), and e1 has 10k (5k connected, 5k not)', async () => {
@@ -1658,12 +1658,12 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(5000);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
 
         expect(Object.keys(results[1].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[1].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[1]).toHaveProperty('score');
+        expect(Object.keys(results[1].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[1].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 1 result when e0 has 1 record, and e1 has 50k + 1 (1 connected, 50k not)', async () => {
@@ -1748,8 +1748,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       /*
@@ -2156,8 +2156,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 1 result with records: →→ (directionality does not match query graph)', async () => {
@@ -2177,8 +2177,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
     });
 
@@ -2200,8 +2200,8 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n1', 'n2', 'n5']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e1_reversed', 'e4']);
-        expect(results[0]).toHaveProperty('score');
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e1_reversed', 'e4']);
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       test('should get 0 results due to unconnected record: ←̽→', async () => {
@@ -2253,9 +2253,9 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2', 'n3']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1', 'e2']);
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1', 'e2']);
 
-        expect(results[0]).toHaveProperty('score');
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       //      // TODO: this test fails
@@ -2324,9 +2324,9 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2', 'n3']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed', 'e2']);
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed', 'e2']);
 
-        expect(results[0]).toHaveProperty('score');
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       /*
@@ -2357,9 +2357,9 @@ describe('Testing QueryResults Module', () => {
         expect(results.length).toEqual(1);
 
         expect(Object.keys(results[0].node_bindings).sort()).toEqual(['n0', 'n1', 'n2', 'n3']);
-        expect(Object.keys(results[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed', 'e2_reversed']);
+        expect(Object.keys(results[0].analyses[0].edge_bindings).sort()).toEqual(['e0', 'e1_reversed', 'e2_reversed']);
 
-        expect(results[0]).toHaveProperty('score');
+        expect(results[0].analyses[0]).toHaveProperty('score');
       });
 
       /*
@@ -2935,7 +2935,7 @@ describe('Testing QueryResults Module', () => {
           records: [record1, record2],
         },
       });
-      expect(queryResult.getResults()[0].edge_bindings.e01.length).toEqual(2);
+      expect(queryResult.getResults()[0].analyses[0].edge_bindings.e01.length).toEqual(2);
     });
   });
 

--- a/__test__/unittest/inferred_mode.test.js
+++ b/__test__/unittest/inferred_mode.test.js
@@ -312,7 +312,11 @@ describe('Test InferredQueryHandler', () => {
   test('combineResponse', () => {
     const InferredQueryHandler = require('../../src/inferred_mode/inferred_mode');
     const inferredQueryHandler = new InferredQueryHandler(
-      {},
+      {
+        options: {
+          provenanceUsesServiceProvider: false
+        }
+      },
       TRAPIQueryHandler,
       queryGraph1,
       [],
@@ -577,7 +581,7 @@ describe('Test InferredQueryHandler', () => {
     expect(Object.values(mergedResults)[0]).toEqual(1);
     expect(creativeLimitHit).toBeTruthy();
     expect(Object.keys(combinedResponse.message.results)).toHaveLength(3);
-    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].analyses[0].score).toEqual(0.75);
+    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].analyses[0].score).toEqual(0.8421052631578949);
     expect(combinedResponse.message.results['fakeCompound3-fakeDisease1'].analyses[0].score).toEqual(0.2);
     expect(combinedResponse.logs).toHaveLength(3);
     expect(combinedResponse.logs[1].message).toMatch('[Template-2]: new fake log');
@@ -731,7 +735,7 @@ describe('Test InferredQueryHandler', () => {
     expect(queryHadResults1).toBeTruthy();
     expect(Object.keys(mergedResults1)).toHaveLength(1);
     expect(creativeLimitHit1).toBeTruthy();
-    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].analyses[0].score).toEqual(0.75);
+    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].analyses[0].score).toEqual(0.8421052631578949);
   });
 
   test('pruneKnowledgeGraph', () => {

--- a/__test__/unittest/inferred_mode.test.js
+++ b/__test__/unittest/inferred_mode.test.js
@@ -398,14 +398,17 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e0: [
-                {
-                  id: 'edgeHash1',
-                },
-              ],
-            },
-            score: 0.5,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e0: [
+                  {
+                    id: 'edgeHash1',
+                  },
+                ],
+              },
+              score: 0.5,
+            }],
           },
           {
             node_bindings: {
@@ -420,14 +423,17 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e0: [
-                {
-                  id: 'edgeHash2',
-                },
-              ],
-            },
-            score: 0.25,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e0: [
+                  {
+                    id: 'edgeHash2',
+                  },
+                ],
+              },
+              score: 0.25,
+            }],
           },
           {
             node_bindings: {
@@ -442,14 +448,17 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e0: [
-                {
-                  id: 'edgeHash3',
-                },
-              ],
-            },
-            score: 0.2,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e0: [
+                  {
+                    id: 'edgeHash3',
+                  },
+                ],
+              },
+              score: 0.2,
+            }],
           },
         ],
       },
@@ -463,6 +472,7 @@ describe('Test InferredQueryHandler', () => {
     const combinedResponse = {
       workflow: [{ id: 'lookup' }],
       message: {
+        auxiliary_graphs: {},
         query_graph: queryGraph1,
         knowledge_graph: {
           nodes: {
@@ -506,14 +516,17 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e01: [
-                {
-                  id: 'edgeHash1',
-                },
-              ],
-            },
-            score: 0.75,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e01: [
+                  {
+                    id: 'edgeHash1',
+                  },
+                ],
+              },
+              score: 0.75,
+            }],
           },
           'fakeCompound3-fakeDisease1': {
             node_bindings: {
@@ -528,14 +541,16 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e01: [
-                {
-                  id: 'edgeHash2',
-                },
-              ],
-            },
-            score: undefined,
+            analyses: [{
+              edge_bindings: {
+                e01: [
+                  {
+                    id: 'edgeHash2',
+                  },
+                ],
+              },
+              score: undefined,
+            }],
           },
         },
       },
@@ -548,16 +563,12 @@ describe('Test InferredQueryHandler', () => {
 
     const { qEdgeID, qEdge, qSubject, qObject } = inferredQueryHandler.getQueryParts();
 
-    let reservedIDs = { nodes: ['n01', 'n02'], edges: ['e01'] };
-
-    const report = inferredQueryHandler.combineResponse(1, trapiQueryHandler0, qEdge, combinedResponse, reservedIDs);
+    const report = inferredQueryHandler.combineResponse(1, trapiQueryHandler0, qEdgeID, qEdge, combinedResponse);
 
     expect(report).toHaveProperty('querySuccess');
     expect(report).toHaveProperty('queryHadResults');
     expect(report).toHaveProperty('mergedResults');
     expect(report).toHaveProperty('creativeLimitHit');
-
-    expect(reservedIDs.edges).toContain('e02');
 
     const { querySuccess, queryHadResults, mergedResults, creativeLimitHit } = report;
     expect(querySuccess).toBeTruthy();
@@ -566,10 +577,10 @@ describe('Test InferredQueryHandler', () => {
     expect(Object.values(mergedResults)[0]).toEqual(1);
     expect(creativeLimitHit).toBeTruthy();
     expect(Object.keys(combinedResponse.message.results)).toHaveLength(3);
-    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].score).toEqual(0.75);
-    expect(combinedResponse.message.results['fakeCompound3-fakeDisease1'].score).toEqual(0.2);
+    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].analyses[0].score).toEqual(0.75);
+    expect(combinedResponse.message.results['fakeCompound3-fakeDisease1'].analyses[0].score).toEqual(0.2);
     expect(combinedResponse.logs).toHaveLength(3);
-    expect(combinedResponse.logs[1].message).toMatch('Template-2');
+    expect(combinedResponse.logs[1].message).toMatch('[Template-2]: new fake log');
 
     const trapiQueryHandler1 = new TRAPIQueryHandler();
     trapiQueryHandler1.getResponse = () => ({
@@ -658,19 +669,22 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e0: [
-                {
-                  id: 'edgeHash1',
-                },
-              ],
-              e01: [
-                {
-                  id: 'edgeHash2',
-                },
-              ],
-            },
-            score: 0.99,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e0: [
+                  {
+                    id: 'edgeHash1',
+                  },
+                ],
+                e01: [
+                  {
+                    id: 'edgeHash2',
+                  },
+                ],
+              },
+              score: 0.99,
+            }],
           },
           {
             node_bindings: {
@@ -685,14 +699,17 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e0: [
-                {
-                  id: 'edgeHash3',
-                },
-              ],
-            },
-            score: undefined,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e0: [
+                  {
+                    id: 'edgeHash3',
+                  },
+                ],
+              },
+              score: undefined,
+            }],
           },
         ],
       },
@@ -703,24 +720,18 @@ describe('Test InferredQueryHandler', () => {
       ],
     });
 
-    reservedIDs = { nodes: ['n01', 'n02'], edges: ['e01'] };
-
     const {
       querySuccess: querySuccess1,
       queryHadResults: queryHadResults1,
       mergedResults: mergedResults1,
       creativeLimitHit: creativeLimitHit1,
-    } = inferredQueryHandler.combineResponse(2, trapiQueryHandler1, qEdge, combinedResponse, reservedIDs);
-
-    expect(reservedIDs.nodes).toContain('n03');
+    } = inferredQueryHandler.combineResponse(2, trapiQueryHandler1, qEdgeID, qEdge, combinedResponse);
 
     expect(querySuccess1).toBeTruthy();
     expect(queryHadResults1).toBeTruthy();
     expect(Object.keys(mergedResults1)).toHaveLength(1);
     expect(creativeLimitHit1).toBeTruthy();
-    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].score).toEqual(0.75);
-    expect(reservedIDs.nodes).toContain('n02');
-    expect(reservedIDs.nodes).toContain('n03');
+    expect(combinedResponse.message.results['fakeCompound1-fakeDisease1'].analyses[0].score).toEqual(0.75);
   });
 
   test('pruneKnowledgeGraph', () => {
@@ -738,6 +749,7 @@ describe('Test InferredQueryHandler', () => {
     const combinedResponse = {
       workflow: [{ id: 'lookup' }],
       message: {
+        auxiliary_graphs: {},
         query_graph: queryGraph1,
         knowledge_graph: {
           nodes: {
@@ -759,11 +771,19 @@ describe('Test InferredQueryHandler', () => {
               predicate: 'biolink:treats',
               subject: 'fakeCompound1',
               object: 'fakeDisease1',
+              attributes: [{
+                attribute_type_id: 'biolink:support_graphs',
+                value: []
+              }],
             },
             edgeHash2: {
               predicate: 'biolink:treats',
               subject: 'fakeCompound3',
               object: 'fakeDisease1',
+              attributes: [{
+                attribute_type_id: 'biolink:support_graphs',
+                value: []
+              }],
             },
           },
         },
@@ -781,14 +801,17 @@ describe('Test InferredQueryHandler', () => {
                 },
               ],
             },
-            edge_bindings: {
-              e01: [
-                {
-                  id: 'edgeHash1',
-                },
-              ],
-            },
-            score: 0.75,
+            analyses: [{
+              resource_id: 'infores:biothings_explorer',
+              edge_bindings: {
+                e01: [
+                  {
+                    id: 'edgeHash1',
+                  },
+                ],
+              },
+              score: 0.75,
+            }],
           },
         ],
       },
@@ -806,7 +829,7 @@ describe('Test InferredQueryHandler', () => {
 
   test('query', async () => {
     const querySpy = jest.spyOn(TRAPIQueryHandler.prototype, 'query');
-    querySpy.mockImplementation(async () => {});
+    querySpy.mockImplementation(async () => { });
     const responseSpy = jest.spyOn(TRAPIQueryHandler.prototype, 'getResponse');
     responseSpy.mockImplementation(() => {
       return {
@@ -847,6 +870,10 @@ describe('Test InferredQueryHandler', () => {
                 subject: 'creativeQuerySubject',
                 object: 'creativeQueryObject',
                 knowledge_type: 'inferred',
+                attributes: [{
+                  attribute_type_id: 'biolink:support_graphs',
+                  value: []
+                }],
               },
             },
           },
@@ -864,14 +891,16 @@ describe('Test InferredQueryHandler', () => {
                   },
                 ],
               },
-              edge_bindings: {
-                e01: [
-                  {
-                    id: 'edgeHash1',
-                  },
-                ],
-              },
-              score: 0.75,
+              analyses: [{
+                edge_bindings: {
+                  e01: [
+                    {
+                      id: 'edgeHash1',
+                    },
+                  ],
+                },
+                score: 0.75,
+              }],
             },
           ],
         },
@@ -947,8 +976,8 @@ describe('Test InferredQueryHandler', () => {
   test('supportedLookups', async () => {
     const { supportedLookups } = require('../../src/inferred_mode/template_lookup');
     const supported = await supportedLookups();
-    expect(supported).toContainEqual({ subject: 'biolink:Drug', predicate: 'biolink:treats', object: 'biolink:Disease', qualifiers: undefined});
-    expect(supported).toContainEqual({ subject: 'biolink:SmallMolecule', predicate: 'biolink:treats', object: 'biolink:PhenotypicFeature', qualifiers: undefined});
+    expect(supported).toContainEqual({ subject: 'biolink:Drug', predicate: 'biolink:treats', object: 'biolink:Disease', qualifiers: undefined });
+    expect(supported).toContainEqual({ subject: 'biolink:SmallMolecule', predicate: 'biolink:treats', object: 'biolink:PhenotypicFeature', qualifiers: undefined });
     expect(supported.length).toBeGreaterThanOrEqual(5 * 2 * 3);
   });
 });


### PR DESCRIPTION
Addresses part of [this issue](https://github.com/biothings/biothings_explorer/issues/665). 

QueryResults
- updated location of edge_bindings and score

inferred_mode
- fixed combineResponse, pruneKnowledgeGraph, and query tests


Test results:
![image](https://github.com/biothings/bte_trapi_query_graph_handler/assets/86498656/58c0ce64-aa02-48bd-8b6f-72575956baac)

