### PR TITLE
feat: add batch-size-limit for ctd subquerying

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,11 @@ const API_BATCH_SIZE = [
     name: 'Multiomics BigGIM-DrugResponse KP API',
     max: 100,
   },
+  {
+    id: '0212611d1c670f9107baf00b77f0889a',
+    name: 'CTD API',
+    max: 80,
+  },
 ];
 
 // max node IDs an edge with no other IDs can have


### PR DESCRIPTION
Addresses https://github.com/biothings/biothings_explorer/issues/584

Note: should work with current x-bte annotation (`supportBatch: false`): I tested and it seemed to work as-intended, ignoring this config entry. So we should be able to merge this PR, then change the x-bte annotation once this is deployed to Prod. 