### PR TITLE
Support periodic cache clearing

### DIFF
--- a/src/cache_handler.ts
+++ b/src/cache_handler.ts
@@ -104,8 +104,8 @@ export default class CacheHandler {
       caching === false
         ? false
         : process.env.RESULT_CACHING !== 'false'
-        ? !(process.env.REDIS_HOST === undefined) && !(process.env.REDIS_PORT === undefined)
-        : false;
+          ? !(process.env.REDIS_HOST === undefined) && !(process.env.REDIS_PORT === undefined)
+          : false;
     this.recordConfig = recordConfig;
     this.logs.push(
       new LogEntry('DEBUG', null, `REDIS cache is ${this.cacheEnabled === true ? '' : 'not'} enabled.`).getLog(),
@@ -231,7 +231,7 @@ export default class CacheHandler {
         if (global.parentPort) {
           global.parentPort.postMessage({ threadId, addCacheKey: redisID });
         }
-        await redisClient.client.usingLock([`redisLock:${redisID}`], 600000, async () => {
+        await redisClient.client.usingLock([`redisLock:${redisID}`, 'redisLock:EdgeCaching'], 600000, async () => {
           try {
             await redisClient.client.delTimeout(redisID); // prevents weird overwrite edge cases
             await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
This PR updates the redis client to allow for edge cache clearing. Additionally, it ensures that the cache handler must acquire a caching lock so that active caching is not interrupted/broken by cache clearing.