### PR TITLE
Edge/Node constraints

### DIFF
--- a/src/graph/knowledge_graph.ts
+++ b/src/graph/knowledge_graph.ts
@@ -9,6 +9,7 @@ import {
   TrapiKGNodes,
   TrapiQualifier,
   TrapiSource,
+  TrapiAttributeConstraint,
 } from '@biothings-explorer/types';
 import KGNode from './kg_node';
 import KGEdge from './kg_edge';
@@ -162,6 +163,8 @@ export default class KnowledgeGraph {
   }
 
   update(bteGraph: BTEGraphUpdate): void {
+    this.nodes = {};
+    this.edges = {};
     Object.keys(bteGraph.nodes).map((node) => {
       this.nodes[bteGraph.nodes[node].primaryCurie] = this._createNode(bteGraph.nodes[node]);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -724,8 +724,6 @@ export default class TRAPIQueryHandler {
     //update query results
     await this.trapiResultsAssembler.update(
       manager.getOrganizedRecords(),
-      this.queryGraphHandler,
-      this.knowledgeGraph.kg,
       !(this.options.smartAPIID || this.options.teamName)
     );
     this.logs = [...this.logs, ...this.trapiResultsAssembler.logs];

--- a/src/index.ts
+++ b/src/index.ts
@@ -557,6 +557,9 @@ export default class TRAPIQueryHandler {
       this.logs.push(new LogEntry('WARNING', null, message).getLog());
       return;
     }
+    if (await this._checkContraints()) {
+      return;
+    }
     const inferredQueryHandler = new InferredQueryHandler(
       this,
       this.queryGraph,
@@ -577,7 +580,7 @@ export default class TRAPIQueryHandler {
     Object.values(this.queryGraph).forEach((item) => {
       Object.values(item).forEach((element: any) => {
         element.constraints?.forEach((constraint: { name: string }) => constraints.add(constraint.name));
-        // element.attribute_constraints?.forEach((constraint: { name: string }) => constraints.add(constraint.name));
+        element.attribute_constraints?.forEach((constraint: { name: string }) => constraints.add(constraint.name));
         // element.qualifier_constraints?.forEach((constraint) => constraints.add(constraint.name));
       });
     });
@@ -593,7 +596,7 @@ export default class TRAPIQueryHandler {
         new LogEntry(
           'ERROR',
           null,
-          `BTE does not currently support any type of constraint. Your query Terminates.`,
+          `BTE does not currently support constraints with creative mode. Your query Terminates.`,
         ).getLog(),
       );
       return true;
@@ -686,10 +689,7 @@ export default class TRAPIQueryHandler {
     }
 
     const queryEdges = await this._processQueryGraph();
-    // TODO remove this when constraints implemented
-    if (await this._checkContraints()) {
-      return;
-    }
+
     if ((this.options.smartAPIID || this.options.teamName) && Object.values(this.queryGraph.edges).length > 1) {
       const message = 'smartAPI/team-specific endpoints only support single-edge queries. Your query terminates.';
       this.logs.push(new LogEntry('WARNING', null, message).getLog());

--- a/src/query_edge.ts
+++ b/src/query_edge.ts
@@ -356,7 +356,6 @@ export default class QEdge {
 
   
   storeRecords(records: Record[]): void {
-    debug((new Error()).stack)
     debug(`(6) Storing records...`);
     // store new records in current edge
     this.records = records;

--- a/src/query_edge.ts
+++ b/src/query_edge.ts
@@ -6,7 +6,7 @@ import { Record, RecordNode, FrozenRecord } from '@biothings-explorer/api-respon
 import QNode from './query_node';
 import { QNodeInfo } from './query_node';
 import { LogEntry, StampedLog } from '@biothings-explorer/utils';
-import { TrapiAttributeConstraint, TrapiQualifierConstraint } from '@biothings-explorer/types';
+import { TrapiAttribute, TrapiAttributeConstraint, TrapiKGEdge, TrapiKGNode, TrapiQualifierConstraint } from '@biothings-explorer/types';
 
 const debug = Debug('bte:biothings-explorer-trapi:QEdge');
 
@@ -32,6 +32,7 @@ interface QEdgeInfo {
   executed?: boolean;
   reverse?: boolean;
   qualifier_constraints?: TrapiQualifierConstraint[];
+  attribute_constraints?: TrapiAttributeConstraint[];
   frozen?: boolean;
   predicates?: string[];
 }
@@ -51,6 +52,7 @@ export default class QEdge {
   object: QNode;
   expanded_predicates: string[];
   qualifier_constraints: TrapiQualifierConstraint[];
+  constraints: TrapiAttributeConstraint[];
   reverse: boolean;
   executed: boolean;
   logs: StampedLog[];
@@ -64,6 +66,7 @@ export default class QEdge {
     this.object = info.frozen === true ? new QNode(info.object as QNodeInfo) : (info.object as QNode);
     this.expanded_predicates = [];
     this.qualifier_constraints = info.qualifier_constraints || [];
+    this.constraints = info.attribute_constraints || [];
 
     this.reverse = this.subject?.getCurie?.() === undefined && this.object?.getCurie?.() !== undefined;
 
@@ -351,188 +354,13 @@ export default class QEdge {
     !this.reverse ? this.subject.updateCuries(combined_curies_2) : this.object.updateCuries(combined_curies_2);
   }
 
-  applyNodeConstraints(): void {
-    debug(`(6) Applying Node Constraints to ${this.records.length} records.`);
-    const kept = [];
-    let save_kept = false;
-    const sub_constraints = this.subject.constraints;
-    if (sub_constraints && sub_constraints.length) {
-      const from = this.reverse ? 'object' : 'subject';
-      debug(`Node (subject) constraints: ${JSON.stringify(sub_constraints)}`);
-      save_kept = true;
-      for (let i = 0; i < this.records.length; i++) {
-        const res = this.records[i];
-        let keep = true;
-        // apply constraints
-        for (let x = 0; x < sub_constraints.length; x++) {
-          const constraint = sub_constraints[x];
-          keep = this.meetsConstraint(constraint, res, from);
-        }
-        // pass or not
-        if (keep) {
-          kept.push(res);
-        }
-      }
-    }
-
-    const obj_constraints = this.object.constraints;
-    if (obj_constraints && obj_constraints.length) {
-      const from = this.reverse ? 'subject' : 'object';
-      debug(`Node (object) constraints: ${JSON.stringify(obj_constraints)}`);
-      save_kept = true;
-      for (let i = 0; i < this.records.length; i++) {
-        const res = this.records[i];
-        let keep = true;
-        // apply constraints
-        for (let x = 0; x < obj_constraints.length; x++) {
-          const constraint = obj_constraints[x];
-          keep = this.meetsConstraint(constraint, res, from);
-        }
-        // pass or not
-        if (keep) {
-          kept.push(res);
-        }
-      }
-    }
-    if (save_kept) {
-      // only override recordss if there was any filtering done.
-      this.records = kept;
-      debug(`(6) Reduced to (${this.records.length}) records.`);
-    } else {
-      debug(`(6) No constraints. Skipping...`);
-    }
-  }
-
-  meetsConstraint(constraint: TrapiAttributeConstraint, record: Record, from: string): boolean {
-    // list of attribute ids in node
-    const available_attributes = [...new Set(Object.keys(record[from].attributes))];
-    // debug(`ATTRS ${JSON.stringify(record[from].normalizedInfo[0]._leafSemanticType)}` +
-    // ` ${from} : ${JSON.stringify(available_attributes)}`);
-    // determine if node even contains right attributes
-    const filters_found = available_attributes.filter((attr) => attr == constraint.id);
-    if (!filters_found.length) {
-      // node doesn't have the attribute needed
-      return false;
-    } else {
-      // match attr by name, parse only attrs of interest
-      const node_attributes = {};
-      filters_found.forEach((filter) => {
-        node_attributes[filter] = record[from].attributes[filter];
-      });
-      switch (constraint.operator) {
-        case '==':
-          for (const key in node_attributes) {
-            if (!isNaN(constraint.value as number)) {
-              if (Array.isArray(node_attributes[key])) {
-                if (
-                  node_attributes[key].includes(constraint.value) ||
-                  node_attributes[key].includes(constraint.value.toString())
-                ) {
-                  return true;
-                }
-              } else {
-                if (
-                  node_attributes[key] == constraint.value ||
-                  node_attributes[key] == constraint.value.toString() ||
-                  node_attributes[key] == parseInt(constraint.value as string)
-                ) {
-                  return true;
-                }
-              }
-            } else {
-              if (Array.isArray(node_attributes[key])) {
-                if (node_attributes[key].includes(constraint.value)) {
-                  return true;
-                }
-              } else {
-                if (
-                  node_attributes[key] == constraint.value ||
-                  node_attributes[key] == constraint.value.toString() ||
-                  node_attributes[key] == parseInt(constraint.value as string)
-                ) {
-                  return true;
-                }
-              }
-            }
-          }
-          return false;
-        case '>':
-          for (const key in node_attributes) {
-            if (Array.isArray(node_attributes[key])) {
-              for (let index = 0; index < node_attributes[key].length; index++) {
-                const element = node_attributes[key][index];
-                if (parseInt(element) > parseInt(constraint.value as string)) {
-                  return true;
-                }
-              }
-            } else {
-              if (parseInt(node_attributes[key]) > parseInt(constraint.value as string)) {
-                return true;
-              }
-            }
-          }
-          return false;
-        case '>=':
-          for (const key in node_attributes) {
-            if (Array.isArray(node_attributes[key])) {
-              for (let index = 0; index < node_attributes[key].length; index++) {
-                const element = node_attributes[key][index];
-                if (parseInt(element) >= parseInt(constraint.value as string)) {
-                  return true;
-                }
-              }
-            } else {
-              if (parseInt(node_attributes[key]) >= parseInt(constraint.value as string)) {
-                return true;
-              }
-            }
-          }
-          return false;
-        case '<':
-          for (const key in node_attributes) {
-            if (Array.isArray(node_attributes[key])) {
-              for (let index = 0; index < node_attributes[key].length; index++) {
-                const element = node_attributes[key][index];
-                if (parseInt(element) > parseInt(constraint.value as string)) {
-                  return true;
-                }
-              }
-            } else {
-              if (parseInt(node_attributes[key]) < parseInt(constraint.value as string)) {
-                return true;
-              }
-            }
-          }
-          return false;
-        case '<=':
-          for (const key in node_attributes) {
-            if (Array.isArray(node_attributes[key])) {
-              for (let index = 0; index < node_attributes[key].length; index++) {
-                const element = node_attributes[key][index];
-                if (parseInt(element) <= parseInt(constraint.value as string)) {
-                  return true;
-                }
-              }
-            } else {
-              if (parseInt(node_attributes[key]) <= parseInt(constraint.value as string)) {
-                return true;
-              }
-            }
-          }
-          return false;
-        default:
-          debug(`Node operator not handled ${constraint.operator}`);
-          return false;
-      }
-    }
-  }
-
+  
   storeRecords(records: Record[]): void {
+    debug((new Error()).stack)
     debug(`(6) Storing records...`);
     // store new records in current edge
     this.records = records;
     // will update records if any constraints are found
-    this.applyNodeConstraints();
     debug(`(7) Updating nodes based on edge records...`);
     this.updateNodesCuries(records);
   }
@@ -576,5 +404,72 @@ export default class QEdge {
 
   getReversedPredicate(predicate: string): string {
     return predicate ? biolink.reverse(predicate) : undefined;
+  }
+
+  meetsConstraints(kgEdge: TrapiKGEdge, kgSub: TrapiKGNode, kgObj: TrapiKGNode): boolean {
+    // edge constraints
+    if (this.constraints) {
+      for (let constraint of this.constraints) {
+        let meets = this._meetsConstraint(constraint, kgEdge.attributes);
+        if (constraint.not) meets = !meets;
+        if (!meets) return false;
+      }
+    }
+
+    // node constraints not fully tested yet (may be some weird behavior with subclsasing)
+    // subject constraints
+    if (this.subject.constraints) {
+      for (let constraint of this.subject.constraints) {
+        let meets = this._meetsConstraint(constraint, kgSub.attributes);
+        if (constraint.not) meets = !meets;
+        if (!meets) return false;
+      }
+    }
+
+    // object constraints
+    if (this.object.constraints) {
+      for (let constraint of this.object.constraints) {
+        let meets = this._meetsConstraint(constraint, kgObj.attributes);
+        if (constraint.not) meets = !meets;
+        if (!meets) return false;
+      }
+    }
+
+    return true;
+  }
+
+  _meetsConstraint(constraint: TrapiAttributeConstraint, attributes?: TrapiAttribute[]): boolean {
+    const edge_attribute = attributes?.find(x => x.attribute_type_id == constraint.id)?.value as any;
+    const constraintValue = constraint.value as any;
+    if (!edge_attribute) {
+      return false;
+    }
+    switch (constraint.operator) {
+      case '==':
+        const array1 = utils.toArray(edge_attribute);
+        const array2 = utils.toArray(constraintValue);
+        for (let a1 of array1) {
+          for (let a2 of array2) {
+            if (a1 == a2) return true;
+          }
+        }
+        return false;
+      case '===':
+        if (Array.isArray(edge_attribute) && Array.isArray(constraintValue)) {
+          if (edge_attribute.length !== constraintValue.length) return false;
+          for (let i = 0; i < edge_attribute.length; i++) {
+            if (edge_attribute[i] !== constraintValue[i]) return false;
+          }
+          return true;
+        }
+        return edge_attribute === constraintValue;
+      case '>':
+        return edge_attribute > constraintValue;
+      case '<':
+        return edge_attribute < constraintValue;
+      default:
+        debug(`Node operator not handled ${constraint.operator}`);
+        return false;
+    }
   }
 }

--- a/src/query_edge.ts
+++ b/src/query_edge.ts
@@ -463,6 +463,18 @@ export default class QEdge {
           return true;
         }
         return edge_attribute === constraintValue;
+      case 'matches':
+        if (typeof constraintValue === 'string') {
+          let regexStr = constraintValue;
+          // make sure regex matches the whole string
+          if (constraintValue.at(0) !== '^') regexStr = '^' + regexStr;
+          if (constraintValue.at(constraintValue.length - 1) !== '$') regexStr += '$';
+          let regex = new RegExp(regexStr);
+          for (let attr of utils.toArray(edge_attribute)) {
+            if (regex.test(attr)) return true;
+          }
+        }
+        return false;
       case '>':
         return edge_attribute > constraintValue;
       case '<':

--- a/src/results_assembly/query_results.ts
+++ b/src/results_assembly/query_results.ts
@@ -151,8 +151,6 @@ export default class TrapiResultsAssembler {
   _getQueryGraphSolutions(
     recordsByQEdgeID: RecordsByQEdgeID,
     qEdgeID: string,
-    queryGraph: QueryGraph,
-    kg: TrapiKnowledgeGraph,
     edgeCount: number,
     queryGraphSolutions: QueryGraphSolutionEdge[][],
     queryGraphSolution: QueryGraphSolutionEdge[],
@@ -192,7 +190,7 @@ export default class TrapiResultsAssembler {
 
     records
       .filter((record) => {
-        return [getMatchingPrimaryCurie(record), undefined].indexOf(primaryCurieToMatch) > -1 && queryGraph.edges[qEdgeID].meetsConstraints(kg.edges[record.recordHash], kg.nodes[kg.edges[record.recordHash].subject], kg.nodes[kg.edges[record.recordHash].object]);
+        return [getMatchingPrimaryCurie(record), undefined].indexOf(primaryCurieToMatch) > -1;
       })
       .forEach((record, i) => {
         // primaryCurie example: 'NCBIGene:1234'
@@ -225,8 +223,6 @@ export default class TrapiResultsAssembler {
           this._getQueryGraphSolutions(
             recordsByQEdgeID,
             connectedQEdgeID,
-            queryGraph,
-            kg,
             edgeCount,
             queryGraphSolutions,
             queryGraphSolution,
@@ -277,7 +273,7 @@ export default class TrapiResultsAssembler {
    * can safely assume every call to update contains all the records.
    *
    */
-  async update(recordsByQEdgeID: RecordsByQEdgeID, queryGraph: QueryGraph, kg: TrapiKnowledgeGraph, shouldScore = true): Promise<void> {
+  async update(recordsByQEdgeID: RecordsByQEdgeID, shouldScore = true): Promise<void> {
     debug(`Updating query results now!`);
 
     let scoreCombos: ScoreCombos;
@@ -322,8 +318,6 @@ export default class TrapiResultsAssembler {
     this._getQueryGraphSolutions(
       recordsByQEdgeID,
       initialQEdgeID,
-      queryGraph,
-      kg,
       qEdgeCount,
       queryGraphSolutions,
       [], // first queryGraphSolution


### PR DESCRIPTION
https://github.com/biothings/biothings_explorer/issues/795

Note: for subclass edges, the constraint is applied to the underlying edge. Ie. if a subclass edge represents A--treats-->B--subclass-->C then the constraints are applied to the A->B edge (and A/B nodes).

Example Query:
```json
{
  "message": {
    "query_graph": {
      "edges": {
        "e0": {
          "predicates": [
            "biolink:treats"
          ],
          "subject": "n0",
          "object": "n1",
          "attribute_constraints": [
            {
              "name": "evidence_count_constraint",
              "id": "biolink:evidence_count",
              "operator": ">",
              "value": 30
            }
          ]
        }
      },
      "nodes": {
        "n0": {
          "categories": [
            "biolink:ChemicalEntity"
          ],
          "constraints": [
            {
                "name": "syn",
                "id": "biolink:synonym",
                "operator": "matches",
                "value": ".*MG.*"
            },
            {
                "name": "xr",
                "id": "biolink:xref",
                "operator": "matches",
                "value": "DrugCentral:1.*"
            }
          ]
        },
        "n1": {
          "categories": [
            "biolink:DiseaseOrPhenotypicFeature"
          ],
          "ids": ["MONDO:0002050"]
        }
      }
    }
  }
}
```