### PR TITLE
PFOCR Result enrichment support for nested support graphs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { QueryHandlerOptions } from '@biothings-explorer/types';
 import BTEGraph from './graph/graph';
 import QEdge from './query_edge';
 import { Telemetry } from '@biothings-explorer/utils';
+import { enrichTrapiResultsWithPfocrFigures } from './results_assembly/pfocr';
 
 // Exports for external availability
 export * from './types';
@@ -702,6 +703,9 @@ export default class TRAPIQueryHandler {
     // prune bteGraph
     this.bteGraph.prune(this.finalizedResults, this.auxGraphs);
     this.bteGraph.notify();
+
+    // Attempt to enrich results with PFOCR figures
+    this.logs = [...this.logs, ...(await enrichTrapiResultsWithPfocrFigures(this.getResponse()))];
 
     span3?.finish();
 

--- a/src/results_assembly/query_results.ts
+++ b/src/results_assembly/query_results.ts
@@ -5,7 +5,6 @@ import { zip } from 'lodash';
 const debug = Debug('bte:biothings-explorer-trapi:QueryResult');
 import { getScores, calculateScore, ScoreCombos } from './score';
 import { Record } from '@biothings-explorer/api-response-transform';
-import { enrichTrapiResultsWithPfocrFigures } from './pfocr';
 import * as config from '../config';
 
 export interface RecordsByQEdgeID {
@@ -477,13 +476,13 @@ export default class TrapiResultsAssembler {
       .sort((result1, result2) => (result2.analyses[0].score ?? 0) - (result1.analyses[0].score ?? 0)); //sort by decreasing score
 
     if (shouldScore) {
-      try {
-        const pfocrEnrichmentLogs = await enrichTrapiResultsWithPfocrFigures(this._results);
-        this.logs.push(...pfocrEnrichmentLogs);
-      } catch (err) {
-        debug('Error enriching with PFOCR figures: ', err);
-        this.logs.push(new LogEntry('DEBUG', null, 'Error enriching with PFOCR figures: ', err).getLog());
-      }
+      // try {
+      //   const pfocrEnrichmentLogs = await enrichTrapiResultsWithPfocrFigures(this._results);
+      //   this.logs.push(...pfocrEnrichmentLogs);
+      // } catch (err) {
+      //   debug('Error enriching with PFOCR figures: ', err);
+      //   this.logs.push(new LogEntry('DEBUG', null, 'Error enriching with PFOCR figures: ', err).getLog());
+      // }
       debug(`Scored ${resultsWithScore} results with NGD score, scored ${resultsWithoutScore} results without NGD.`);
       this.logs.push(
         new LogEntry(
@@ -503,7 +502,7 @@ export default class TrapiResultsAssembler {
         new LogEntry(
           'DEBUG',
           null,
-          `Scoring/PFOCR figures disabled for KP endpoints; results not scored. Use ARA endpoints (/v1/query or /v1/asyncquery) for scoring/PFOCR figures.`,
+          `Scoring disabled for KP endpoints; results not scored. Use ARA endpoints (/v1/query or /v1/asyncquery) for scoring.`,
           {
             type: 'scoring',
             scored: resultsWithScore,


### PR DESCRIPTION
_Addresses https://github.com/biothings/biothings_explorer/issues/837_

- No longer runs a 'pre-check' on QNodes, instead iterating through results, acquiring all result-related nodes, and then building combos. If no results have 2+ nodes which are supported for lookup, enrichment is skipped.
- No longer runs as part of results assembly, instead running as a near-final transformation once results/kg/aux-graphs/subclassing have been handled.
- Adds `pfocrUrl` to enrichment objects.