### PR TITLE
Inferred-mode response merging: use more specific criteria for direct-edge handling

### DIFF
--- a/src/inferred_mode/inferred_mode.ts
+++ b/src/inferred_mode/inferred_mode.ts
@@ -320,7 +320,7 @@ export default class InferredQueryHandler {
             biolink.getDescendantPredicates(predicate).includes(boundEdge.predicate),
         ),
         // All query qualifiers (if any) are accounted for (more is fine)
-        qEdge.qualifier_constraints.every(({ qualifier_set }) => {
+        qEdge.qualifier_constraints.some(({ qualifier_set }) => {
           return qualifier_set.every((queryQualifier) =>
             boundEdge.qualifiers.some(
               (qualifier) =>


### PR DESCRIPTION
*Addresses https://github.com/biothings/biothings_explorer/issues/839*

To use special direct edge handling, a template result must:
- Be a direct-edge (single-hop) result
- Bind an edge which is the type same as, or a descendant type of, the query edge
- Satisfy at least one qualifier set of the query edge completely