### PR TITLE
do not include records with no curies in qedge

### DIFF
--- a/src/edge_manager.ts
+++ b/src/edge_manager.ts
@@ -207,11 +207,8 @@ export default class QueryEdgeManager {
       const objectIDs = [record.object.original, record.object.curie, ...record.object.equivalentCuries];
 
       // there must be at least a minimal intersection
-      const subjectMatch =
-        subjectIDs.some((curie) => execSubjectCuries.includes(curie)) || execSubjectCuries.length === 0;
-      const objectMatch = objectIDs.some((curie) => execObjectCuries.includes(curie)) || execObjectCuries.length === 0;
-
-      //if both ends match then keep record
+      const subjectMatch = subjectIDs.some((curie) => execSubjectCuries.includes(curie));
+      const objectMatch = objectIDs.some((curie) => execObjectCuries.includes(curie));
 
       // Don't keep self-edges
       const selfEdge = [...subjectIDs].some((curie) => objectIDs.includes(curie));


### PR DESCRIPTION
Fixes https://github.com/biothings/biothings_explorer/issues/840

Records are already stored in the QEdge before they are filtered, this means QNode curie intersection has already occurred. Therefore, the only case in which a QNode would have no curies is if there was no intersection: thus, no records should be kept.