### PR TITLE
add biolink prefix to qualified_predicate

### DIFF
--- a/data/templateGroups.json
+++ b/data/templateGroups.json
@@ -21,7 +21,7 @@
                ],
     "predicate": ["affects"],
     "qualifiers": {
-      "qualified_predicate": "causes",
+      "qualified_predicate": "biolink:causes",
       "object_aspect_qualifier": "activity_or_abundance",
       "object_direction_qualifier": "increased"
     }, 
@@ -41,7 +41,7 @@
                ],
     "predicate": ["affects"],
     "qualifiers": {
-      "qualified_predicate": "causes",
+      "qualified_predicate": "biolink:causes",
       "object_aspect_qualifier": "activity_or_abundance",
       "object_direction_qualifier": "decreased"
     }, 


### PR DESCRIPTION
In https://github.com/NCATSTranslator/Feedback/issues/914, BTE is producing a result that fails TRAPI validation. The detailed validation error is: 

```
		Critical:
		* Trapi:
		=> Schema validation error
			$ global
				# v1.5.0
				- component | json_path | reason: 
					KnowledgeGraph | $.edges.inferred-CHEBI:26216-affects-UniProtKB:Q8N6C7.qualifiers[0].qualifier_type_id | 'qualified_predicate' does not match '^biolink:[a-z][a-z_]*$'
```

The relevant section of the TRAPI is 

```
                        "inferred-CHEBI:26216-affects-UniProtKB:Q8N6C7": {
                            "subject": "CHEBI:26216",
                            "object": "UniProtKB:Q8N6C7",
                            "predicate": "biolink:affects",
                            "sources": [
                                  [snip]
                            ],
                            "attributes": [
                                  [snip]
                            ],
                            "qualifiers": [
                                {
                                    "qualifier_type_id": "qualified_predicate",
                                    "qualifier_value": "causes"
                                },
                                {
                                    "qualifier_type_id": "object_aspect_qualifier",
                                    "qualifier_value": "activity_or_abundance"
                                },
                                {
                                    "qualifier_type_id": "object_direction_qualifier",
                                    "qualifier_value": "increased"
                                }
                            ]
                        },
```

I _believe_ this PR would fix this error, but would like @colleenXu or @tokebe to review...