### PR TITLE
Reduce query ids by only using bound nodes for pfocr figure search

### DIFF
--- a/src/results_assembly/pfocr.ts
+++ b/src/results_assembly/pfocr.ts
@@ -264,7 +264,11 @@ export async function enrichTrapiResultsWithPfocrFigures(response: TrapiResponse
     const resultCuries: Set<string> = [...resultNodes].reduce((curies, node) => {
       const equivalentCuries =
         (node.attributes?.find((attribute) => attribute.attribute_type_id === 'biolink:xref')?.value as string[]) ?? [];
-      equivalentCuries.forEach((curie) => curies.add(curie.split(':').slice(1).join('')));
+      equivalentCuries.forEach((curie) => {
+        const prefix = curie.split(':')[0];
+        const suffix = curie.replace(`${prefix}:`, '');
+        if (Object.keys(SUPPORTED_PREFIXES).includes(prefix)) curies.add(suffix);
+      });
       return curies;
     }, new Set<string>());
 


### PR DESCRIPTION
Doesn't address all relevancy problems due to creative mode interactions (pfocr augmentation happens at template-level, therefor not grabbing explicitly the bound nodes in the final inferred response), however this should ensure slightly higher relevancy of a given figure to the template it came from, in turn making it slightly more relevant to the overall inferred result.

Most importantly, because only the bound nodes are used, fewer ids are being used to query pfocr, which should decrease overall pfocr search time. Full `traverseResultforNodes` is still used in scoring and for `matchedQueries`, so the score should still be slightly higher-quality.