### PR TITLE
Pathfinder dryrun feature

### DIFF
--- a/__test__/unittest/pf_template_generator.test.ts
+++ b/__test__/unittest/pf_template_generator.test.ts
@@ -3,13 +3,15 @@ import generateTemplates from '../../src/inferred_mode/pf_template_generator';
 describe('Test Pathfinder Template Generator', () => {
   test('Should generate correct templates', async () => {
     const sub = {
-      categories: ['biolink:Drug']
+      categories: ['biolink:Drug'],
+      ids: ['subject']
     };
     const un = {
       categories: ['biolink:Gene']
     };
     const obj = {
-      categories: ['biolink:Disease']
+      categories: ['biolink:Disease'],
+      ids: ['object']
     };
 
     const templatesWithUnCat = await generateTemplates(sub, un, obj);
@@ -21,12 +23,14 @@ describe('Test Pathfinder Template Generator', () => {
         "creativeQuerySubject": {
           "categories": [
             "biolink:Drug"
-          ]
+          ],
+          "ids": ["subject"]
         },
         "creativeQueryObject": {
           "categories": [
             "biolink:Disease"
-          ]
+          ],
+          "ids": ["object"]
         },
         "un": {
           "categories": [
@@ -57,7 +61,8 @@ describe('Test Pathfinder Template Generator', () => {
             "biolink:contributes_to"
           ]
         }
-      }
+      },
+      "log": "(subject) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (Gene) -(gene_associated_with_condition,biomarker_for,affects,contributes_to)-> (object)",
     });
     expect(templatesWithoutUnCat[0]).toEqual(templatesWithUnCat[0]);
 
@@ -67,12 +72,14 @@ describe('Test Pathfinder Template Generator', () => {
         "creativeQuerySubject": {
           "categories": [
             "biolink:Drug"
-          ]
+          ],
+          "ids": ["subject"]
         },
         "creativeQueryObject": {
           "categories": [
             "biolink:Disease"
-          ]
+          ],
+          "ids": ["object"]
         },
         "un": {
           "categories": [
@@ -125,7 +132,8 @@ describe('Test Pathfinder Template Generator', () => {
             "biolink:occurs_in"
           ]
         }
-      }
+      },
+      "log": "(subject) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (Gene) -(related_to_at_instance_level,affects,contributes_to,participates_in,regulates,regulated_by,affected_by,interacts_with,correlated_with)-> (AnatomicalEntity,BiologicalProcessOrActivity,ChemicalEntity) -(related_to_at_instance_level,affects,affected_by,occurs_in)-> (object)"
     });
     expect(templatesWithoutUnCat[1]).toEqual(templatesWithUnCat[1]);
 
@@ -135,12 +143,14 @@ describe('Test Pathfinder Template Generator', () => {
         "creativeQuerySubject": {
           "categories": [
             "biolink:Drug"
-          ]
+          ],
+          "ids": ["subject"]
         },
         "creativeQueryObject": {
           "categories": [
             "biolink:Disease"
-          ]
+          ],
+          "ids": ["object"]
         },
         "un": {
           "categories": [
@@ -187,20 +197,23 @@ describe('Test Pathfinder Template Generator', () => {
             "biolink:contributes_to"
           ]
         }
-      }
+      },
+      "log": "(subject) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (Gene) -(regulates,regulated_by,affects,affected_by,interacts_with)-> (Gene) -(gene_associated_with_condition,biomarker_for,affects,contributes_to)-> (object)"
     });
     expect(templatesWithoutUnCat[2]).toEqual(templatesWithUnCat[2]);
   });
 
   test('template with no predicates should not have predicate property', async () => {
     const sub = {
-      categories: ['biolink:Drug']
+      categories: ['biolink:Drug'],
+      ids: ['subject']
     };
     const un = {
       categories: ['biolink:Dummy']
     };
     const obj = {
-      categories: ['biolink:Drug']
+      categories: ['biolink:Drug'],
+      ids: ['object']
     };
 
     const templates = await generateTemplates(sub, un, obj);

--- a/src/inferred_mode/pathfinder.ts
+++ b/src/inferred_mode/pathfinder.ts
@@ -87,6 +87,31 @@ export default class PathfinderQueryHandler {
     debug(logMessage);
     this.logs.push(new LogEntry('INFO', null, logMessage).getLog());
 
+    // log all the templates
+    const templateNames = ['A', 'B', 'C'];
+    for (let i = 0; i < 3; i++) {
+      let logMessage = `Pathfinder Template ${templateNames[i]}: ${templates[i].log}`;
+      debug(logMessage);
+      this.logs.push(new LogEntry('INFO', null, logMessage).getLog());
+    }
+
+    // handle dry run scenario
+    if (this.options.dryrun_pathfinder) {
+      return {
+        description: `Pathfinder Dry Run completed successfully. No results received. ${templates.length} templates generated.`,
+        schema_version: global.SCHEMA_VERSION,
+        biolink_version: global.BIOLINK_VERSION,
+        workflow: [{ id: this.options.smartAPIID || this.options.teamName ? 'lookup' : 'lookup_and_score' }],
+        message: {
+          query_graph: this.parent.originalQueryGraph,
+          knowledge_graph: this.parent.knowledgeGraph.kg,
+          auxiliary_graphs: {},
+          results: [],
+        },
+        logs: this.logs.map((log) => log.toJSON()),
+      };
+    }
+
     // remove unpinned node & all edges involving unpinned node for now
     delete this.queryGraph.nodes[this.unpinnedNodeId];
 

--- a/src/inferred_mode/pf_template_generator.ts
+++ b/src/inferred_mode/pf_template_generator.ts
@@ -76,7 +76,7 @@ export default async function generateTemplates(sub: TrapiQNode, un: TrapiQNode,
       }
     },
     generateLog: function() {
-      return `Sub (${sub.categories.join(',')}) --${[...this.edges.sub_un.predicates].join(',')}--> Un (${Array.from(this.nodes.un.categories).join(',')}) --${[...this.edges.un_obj.predicates].join(',')}--> Obj (${obj.categories.join(',')})`.replace(/biolink:/g, '');
+      return `(${sub.ids.join(',')}) -(${[...this.edges.sub_un.predicates].join(',')})-> (${Array.from(this.nodes.un.categories).join(',')}) -(${[...this.edges.un_obj.predicates].join(',')})-> (${obj.ids.join(',')})`.replace(/biolink:/g, '');
     }
   };
   const templateB = {
@@ -104,7 +104,7 @@ export default async function generateTemplates(sub: TrapiQNode, un: TrapiQNode,
       }
     },
     generateLog: function() {
-      return `Sub (${sub.categories.join(',')}) --${[...this.edges.sub_un.predicates].join(',')}--> Un (${Array.from(this.nodes.un.categories).join(',')}) --${[...this.edges.un_b.predicates].join(',')}--> Nb (${Array.from(this.nodes.nb.categories).join(',')}) --${[...this.edges.b_obj.predicates].join(',')}--> Obj (${obj.categories.join(',')})`.replace(/biolink:/g, '');
+      return `(${sub.ids.join(',')}) -(${[...this.edges.sub_un.predicates].join(',')})-> (${Array.from(this.nodes.un.categories).join(',')}) -(${[...this.edges.un_b.predicates].join(',')})-> (${Array.from(this.nodes.nb.categories).join(',')}) -(${[...this.edges.b_obj.predicates].join(',')})-> (${obj.ids.join(',')})`.replace(/biolink:/g, '');
     }
   };
   const templateC = {
@@ -132,7 +132,7 @@ export default async function generateTemplates(sub: TrapiQNode, un: TrapiQNode,
       }
     },
     generateLog: function() {
-      return `Sub (${sub.categories.join(',')}) --${[...this.edges.sub_c.predicates].join(',')}--> Nc (${Array.from(this.nodes.nc.categories).join(',')}) --${[...this.edges.c_un.predicates].join(',')}--> Un (${Array.from(this.nodes.un.categories).join(',')}) --${[...this.edges.un_obj.predicates].join(',')}--> Obj (${obj.categories.join(',')})`.replace(/biolink:/g, '');
+      return `(${sub.ids.join(',')}) -(${[...this.edges.sub_c.predicates].join(',')})-> (${Array.from(this.nodes.nc.categories).join(',')}) -(${[...this.edges.c_un.predicates].join(',')})-> (${Array.from(this.nodes.un.categories).join(',')}) -(${[...this.edges.un_obj.predicates].join(',')})-> (${obj.ids.join(',')})`.replace(/biolink:/g, '');
     }
   };
   for (const subCat of sub.categories) {


### PR DESCRIPTION
Pass in the POST option dryrun_pathfinder=true (same format as the dryrun option)

Example logs:
```json
{
      "timestamp": "2024-09-09T22:47:53.576Z",
      "level": "INFO",
      "message": "Pathfinder Template A: (PUBCHEM.COMPOUND:445154) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (Gene) -(regulates,regulated_by,affects,affected_by,interacts_with)-> (NCBIGene:2739)",
      "code": null
    },
    {
      "timestamp": "2024-09-09T22:47:53.576Z",
      "level": "INFO",
      "message": "Pathfinder Template B: (PUBCHEM.COMPOUND:445154) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (Gene) -(regulates,regulated_by,affects,affected_by,interacts_with,correlated_with)-> (Gene,ChemicalEntity) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (NCBIGene:2739)",
      "code": null
    },
    {
      "timestamp": "2024-09-09T22:47:53.576Z",
      "level": "INFO",
      "message": "Pathfinder Template C: (PUBCHEM.COMPOUND:445154) -(regulates,regulated_by,affects,affected_by,interacts_with,associated_with)-> (Gene) -(regulates,regulated_by,affects,affected_by,interacts_with)-> (Gene) -(regulates,regulated_by,affects,affected_by,interacts_with)-> (NCBIGene:2739)",
      "code": null
    },

```

https://github.com/biothings/biothings_explorer/issues/862