### PR TITLE
do not allow edge attribtues with same type id for trapi

### DIFF
--- a/src/graph/knowledge_graph.ts
+++ b/src/graph/knowledge_graph.ts
@@ -175,6 +175,7 @@ export default class KnowledgeGraph {
 
     //handle TRAPI APIs (Situation A of https://github.com/biothings/BioThings_Explorer_TRAPI/issues/208) and APIs that define 'edge-atributes' in x-bte
     const seenPmids = new Set();
+    const seenAttrs = new Set();
     kgEdge.attributes['edge-attributes']?.forEach((attribute) => {
       // Do not add multiple SemmedDB sentences/other "supporting study results" from the same publication
       if (attribute.attribute_type_id === "biolink:has_supporting_study_result" && attribute?.attributes?.find((attr) => attr.attribute_type_id === "biolink:publications")) {
@@ -186,7 +187,11 @@ export default class KnowledgeGraph {
         } 
         seenPmids.add(publication);
       }
-
+      // Do not add duplicate attributes for TRAPi
+      else if (seenAttrs.has(attribute.attribute_type_id)) {
+        return;
+      }
+      seenAttrs.add(attribute.attribute_type_id);
       attributes.push(attribute);
     });
 


### PR DESCRIPTION
https://github.com/biothings/biothings_explorer/issues/891

Previously, if a edge had mutliple TRAPI records, the last TRAPI record would decide the edge-attributes, which meant no duplicates (and no merging behavior).

With the SemmedDB sentences PR (https://github.com/biothings/bte_trapi_query_graph_handler/pull/219), it was required in that situation to merge multiple (suporting publication) edge-attributes from the different records composing an edge.

Here, I have changed the behavior for all attributes (except the ones used in SemmedDB sentences) to a behavior where if multiple  TRAPI records have edge attributes with the same attribute_type_id, only the first one will be taken.